### PR TITLE
Fix: generate RPC client with spaces and hyphens

### DIFF
--- a/lokerpc/codegen/common.go
+++ b/lokerpc/codegen/common.go
@@ -1,6 +1,7 @@
 package codegen
 
 import (
+	"fmt"
 	"sort"
 	"strings"
 )
@@ -12,6 +13,14 @@ func capitalize(s string) string {
 	return strings.ToUpper(s[:1]) + s[1:]
 }
 
+func pascalCase(kebabCase string) string {
+	var sb strings.Builder
+	for _, s := range strings.Split(kebabCase, "-") {
+		sb.WriteString(capitalize(s))
+	}
+	return sb.String()
+}
+
 func sortedKeys[T any](m map[string]T) []string {
 	keys := make([]string, 0, len(m))
 	for k := range m {
@@ -19,4 +28,11 @@ func sortedKeys[T any](m map[string]T) []string {
 	}
 	sort.Strings(keys)
 	return keys
+}
+
+func quoteSpaces(s string) string {
+	if strings.Contains(s, " ") {
+		return fmt.Sprintf("%q", s)
+	}
+	return s
 }

--- a/lokerpc/codegen/common.go
+++ b/lokerpc/codegen/common.go
@@ -2,6 +2,7 @@ package codegen
 
 import (
 	"fmt"
+	"regexp"
 	"sort"
 	"strings"
 )
@@ -30,9 +31,11 @@ func sortedKeys[T any](m map[string]T) []string {
 	return keys
 }
 
-func quoteSpaces(s string) string {
-	if strings.Contains(s, " ") {
-		return fmt.Sprintf("%q", s)
+var notRequireQuotes = regexp.MustCompile(`^[a-z_$][a-z0-9_$]*$`)
+
+func quoteFieldNames(s string) string {
+	if notRequireQuotes.MatchString(s) {
+		return s
 	}
-	return s
+	return fmt.Sprintf("%q", s)
 }

--- a/lokerpc/codegen/common.go
+++ b/lokerpc/codegen/common.go
@@ -31,7 +31,7 @@ func sortedKeys[T any](m map[string]T) []string {
 	return keys
 }
 
-var notRequireQuotes = regexp.MustCompile(`^[a-z_$][a-z0-9_$]*$`)
+var notRequireQuotes = regexp.MustCompile(`(?i)^[a-z_$][a-z0-9_$]*$`)
 
 func quoteFieldNames(s string) string {
 	if notRequireQuotes.MatchString(s) {

--- a/lokerpc/codegen/testdata/spaces-hyphens.json
+++ b/lokerpc/codegen/testdata/spaces-hyphens.json
@@ -1,0 +1,38 @@
+{
+  "serviceName": "hyphenated-service-name",
+  "help": "",
+  "multiArg": false,
+  "definitions": {
+    "User": {
+      "properties": {
+        "User ID": {
+          "type": "string"
+        },
+        "First Name": {
+          "type": "string"
+        },
+        "Last Name": {
+          "type": "string"
+        }
+      }
+    }
+  },
+  "interfaces": [
+    {
+      "help": "hello1 method",
+      "methodName": "getUser",
+      "methodTimeout": 60000,
+      "paramNames": [],
+      "requestTypeDef": {
+        "properties": {
+          "id": {
+            "type": "string"
+          }
+        }
+      },
+      "responseTypeDef": {
+        "ref": "User"
+      }
+    }
+  ]
+}

--- a/lokerpc/codegen/testdata/spaces-hyphens.json
+++ b/lokerpc/codegen/testdata/spaces-hyphens.json
@@ -5,16 +5,61 @@
   "definitions": {
     "User": {
       "properties": {
-        "User_ID": {
+        "snake_case": {
           "type": "string"
         },
-        "First-Name": {
+        "Snake_Case": {
           "type": "string"
         },
-        "Last Name": {
+        "kebab-case": {
           "type": "string"
         },
-        "Email@Address": {
+        "Kebab-Case": {
+          "type": "string"
+        },
+        "camelCase": {
+          "type": "string"
+        },
+        "lowercase": {
+          "type": "string"
+        },
+        "PascalCase": {
+          "type": "string"
+        },
+        "dot.separated": {
+          "type": "string"
+        },
+        "comma,separated": {
+          "type": "string"
+        },
+        "semicolonsuffixed;": {
+          "type": "string"
+        },
+        "email@address": {
+          "type": "string"
+        },
+        "@prefixed": {
+          "type": "string"
+        },
+        "#prefixed": {
+          "type": "string"
+        },
+        "$prefixed": {
+          "type": "string"
+        },
+        ".prefixed": {
+          "type": "string"
+        },
+        "1numberedStart": {
+          "type": "string"
+        },
+        "numberedEnd1": {
+          "type": "string"
+        },
+        "\"DoubleQuotes\"": {
+          "type": "string"
+        },
+        "'SingleQuotes'": {
           "type": "string"
         }
       }

--- a/lokerpc/codegen/testdata/spaces-hyphens.json
+++ b/lokerpc/codegen/testdata/spaces-hyphens.json
@@ -5,13 +5,16 @@
   "definitions": {
     "User": {
       "properties": {
-        "User ID": {
+        "User_ID": {
           "type": "string"
         },
-        "First Name": {
+        "First-Name": {
           "type": "string"
         },
         "Last Name": {
+          "type": "string"
+        },
+        "Email@Address": {
           "type": "string"
         }
       }

--- a/lokerpc/codegen/testdata/spaces-hyphens.json.ts
+++ b/lokerpc/codegen/testdata/spaces-hyphens.json.ts
@@ -1,0 +1,27 @@
+import { RPCContextClient } from "@loke/http-rpc-client";
+import { Context } from "@loke/context";
+
+export type User = {
+  "First Name": string;
+  "Last Name": string;
+  "User ID": string;
+};
+
+export type GetUserRequest = {
+  id: string;
+};
+
+/**
+ * 
+ */
+export class HyphenatedServiceNameService extends RPCContextClient {
+  constructor(baseUrl: string) {
+    super(baseUrl, "hyphenated-service-name")
+  }
+  /**
+   * hello1 method
+   */
+  getUser(ctx: Context, req: GetUserRequest): Promise<User> {
+    return this.request(ctx, "getUser", req);
+  }
+}

--- a/lokerpc/codegen/testdata/spaces-hyphens.json.ts
+++ b/lokerpc/codegen/testdata/spaces-hyphens.json.ts
@@ -2,10 +2,25 @@ import { RPCContextClient } from "@loke/http-rpc-client";
 import { Context } from "@loke/context";
 
 export type User = {
-  "Email@Address": string;
-  "First-Name": string;
-  "Last Name": string;
-  "User_ID": string;
+  "\"DoubleQuotes\"": string;
+  "#prefixed": string;
+  $prefixed: string;
+  "'SingleQuotes'": string;
+  ".prefixed": string;
+  "1numberedStart": string;
+  "@prefixed": string;
+  "Kebab-Case": string;
+  PascalCase: string;
+  Snake_Case: string;
+  camelCase: string;
+  "comma,separated": string;
+  "dot.separated": string;
+  "email@address": string;
+  "kebab-case": string;
+  lowercase: string;
+  numberedEnd1: string;
+  "semicolonsuffixed;": string;
+  snake_case: string;
 };
 
 export type GetUserRequest = {

--- a/lokerpc/codegen/testdata/spaces-hyphens.json.ts
+++ b/lokerpc/codegen/testdata/spaces-hyphens.json.ts
@@ -2,9 +2,10 @@ import { RPCContextClient } from "@loke/http-rpc-client";
 import { Context } from "@loke/context";
 
 export type User = {
-  "First Name": string;
+  "Email@Address": string;
+  "First-Name": string;
   "Last Name": string;
-  "User ID": string;
+  "User_ID": string;
 };
 
 export type GetUserRequest = {

--- a/lokerpc/codegen/typescript.go
+++ b/lokerpc/codegen/typescript.go
@@ -41,7 +41,7 @@ func GenTypescriptType(schema jtd.Schema) string {
 	case jtd.FormProperties:
 		t += "{\n"
 		for _, k := range sortedKeys(schema.Properties) {
-			t += "  " + k + ": " + GenTypescriptType(schema.Properties[k]) + ";\n"
+			t += "  " + quoteSpaces(k) + ": " + GenTypescriptType(schema.Properties[k]) + ";\n"
 		}
 		for _, k := range sortedKeys(schema.OptionalProperties) {
 			t += "  " + k + "?: " + GenTypescriptType(schema.OptionalProperties[k]) + ";\n"
@@ -97,7 +97,7 @@ func GenTypescriptClient(w io.Writer, meta lokerpc.Meta) error {
 
 	b.WriteString("\n")
 	tsDocComment(b, meta.Help, "")
-	b.WriteString("export class " + capitalize(meta.ServiceName) + "Service extends RPCContextClient {\n")
+	b.WriteString("export class " + pascalCase(meta.ServiceName) + "Service extends RPCContextClient {\n")
 	b.WriteString("  constructor(baseUrl: string) {\n")
 	b.WriteString("    super(baseUrl, \"" + meta.ServiceName + "\")\n")
 	b.WriteString("  }\n")

--- a/lokerpc/codegen/typescript.go
+++ b/lokerpc/codegen/typescript.go
@@ -41,7 +41,7 @@ func GenTypescriptType(schema jtd.Schema) string {
 	case jtd.FormProperties:
 		t += "{\n"
 		for _, k := range sortedKeys(schema.Properties) {
-			t += "  " + quoteSpaces(k) + ": " + GenTypescriptType(schema.Properties[k]) + ";\n"
+			t += "  " + quoteFieldNames(k) + ": " + GenTypescriptType(schema.Properties[k]) + ";\n"
 		}
 		for _, k := range sortedKeys(schema.OptionalProperties) {
 			t += "  " + k + "?: " + GenTypescriptType(schema.OptionalProperties[k]) + ";\n"


### PR DESCRIPTION
Encountered this issue with Stripe Payments which has spaces in some field names on metadata types, and a hyphen in the service name.

Will now wrap field names in quotes if required, and service name will be PascalCased. No change to any services that do not require this.

Added a test case to confirm.