### PR TITLE
feat: set up ability to generate void type from golang RPC defs

### DIFF
--- a/lokerpc/server.go
+++ b/lokerpc/server.go
@@ -84,6 +84,7 @@ type EndpointCodec struct {
 	requestType      reflect.Type
 	responseType     reflect.Type
 	errOnNilResponse bool
+	voidResponse     bool
 }
 
 // EndpointCodecMap maps the Request.Method to the proper EndpointCodec
@@ -164,6 +165,12 @@ func MakeStandardEndpointCodec[Req any, Res any](method StandardMethod[Req, Res]
 func NoNilResponse() EndpointCodecOption {
 	return func(ec *EndpointCodec) {
 		ec.errOnNilResponse = true
+	}
+}
+
+func VoidResponse() EndpointCodecOption {
+	return func(ec *EndpointCodec) {
+		ec.voidResponse = true
 	}
 }
 
@@ -258,7 +265,11 @@ func MountHandlers(logger log.Logger, mux Mux, services ...*Service) {
 				endMeta.RequestTypeDef = TypeSchema(ec.requestType, defs)
 				endMeta.RequestTypeDef.Nullable = false
 			}
-			if ec.responseType != nil {
+			if ec.voidResponse {
+				endMeta.ResponseTypeDef = &jtd.Schema{
+					Metadata: map[string]any{"void": true},
+				}
+			} else if ec.responseType != nil {
 				endMeta.ResponseTypeDef = TypeSchema(ec.responseType, defs)
 				if ec.errOnNilResponse {
 					endMeta.ResponseTypeDef.Nullable = false

--- a/lokerpc/server_test.go
+++ b/lokerpc/server_test.go
@@ -1,0 +1,57 @@
+package lokerpc
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-kit/log"
+)
+
+type voidTestReq struct {
+	Name string `json:"name"`
+}
+
+type voidTestRes struct {
+	ID string `json:"id"`
+}
+
+func voidTestMethod(_ context.Context, _ voidTestReq) (voidTestRes, error) {
+	return voidTestRes{ID: "x"}, nil
+}
+
+func TestMountHandlersVoidResponse(t *testing.T) {
+	svc := NewService("svc", "help", EndpointCodecMap{
+		"m": MakeStandardEndpointCodec(voidTestMethod, "method", VoidResponse()),
+	})
+
+	mux := http.NewServeMux()
+	MountHandlers(log.NewNopLogger(), mux, svc)
+
+	req := httptest.NewRequest(http.MethodGet, "/rpc/svc", nil)
+	rw := httptest.NewRecorder()
+	mux.ServeHTTP(rw, req)
+
+	if rw.Code != http.StatusOK {
+		t.Fatalf("unexpected status: got %d want %d", rw.Code, http.StatusOK)
+	}
+
+	var meta Meta
+	if err := json.Unmarshal(rw.Body.Bytes(), &meta); err != nil {
+		t.Fatalf("decode meta: %v", err)
+	}
+
+	if len(meta.Interfaces) != 1 {
+		t.Fatalf("unexpected interface count: got %d want 1", len(meta.Interfaces))
+	}
+
+	got := meta.Interfaces[0].ResponseTypeDef
+	if got == nil {
+		t.Fatal("responseTypeDef is nil")
+	}
+	if got.Metadata["void"] != true {
+		t.Fatalf("responseTypeDef.metadata.void: got %#v want true", got.Metadata["void"])
+	}
+}


### PR DESCRIPTION
Internal change only

This pull request introduces support for marking RPC endpoint responses as "void" (i.e., no meaningful response), and ensures this is reflected in the generated API metadata. It also adds a test to verify the new functionality.

Check only those that apply to this change.

- [x] Self-reviewed code, removed extraneous comments, debug logging, checked code style
- [x] No change to users after merge (off-by-default configuration, feature flag, alt URL, etc.) and can be disabled if issues arise (if this is not the case we may need stakeholder signoff)
- [ ] Changes are documented (README, wiki, etc)
- [ ] Automated tests added or existing tests cover the new functionality or changes
- [ ] Manually tested changes
- [ ] Metrics added to track the usage/performance
- [x] I am confident I can revert this change
- [ ] Database migrations are reversible without data loss (if applicable)
- [ ] Performance impact is acceptable (if applicable)
- [ ] Any new dependencies are justified or have been approved (if applicable)
- [x] **This is NOT a high risk change** (if it is, please follow the high-risk change process)

### Testing Evidence

What evidence supports that you have tested this change?

- [ ] Test cases cover the new functionality or changes
- [ ] Screenshots or logs of the changes (if applicable)
- [ ] Performance benchmarks (if applicable)
- [ ] Storybook cases (if applicable)

## Reviewer Checklist

Note: if this PR affects authentication or payments please seek a secondary tester.

- [ ] I am ok with code style and functionality
- [ ] I have personally tested the feature
- [ ] My review was not rushed due to time constraints
