### PR TITLE
Enforce Trailing Slash On Go RPC URLs

### DIFF
--- a/lokerpc/client.go
+++ b/lokerpc/client.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/LOKE/pkg/requestid"
 )
@@ -15,7 +16,7 @@ func NewClient(baseURL string) Client {
 }
 
 func newClientWithClient(baseURL string, client *http.Client) Client {
-	return Client{bURL: baseURL, client: client}
+	return Client{bURL: normalizeBaseURL(baseURL), client: client}
 }
 
 // NOTE: Maybe this should be exported, leaving it for now -- Dom
@@ -48,6 +49,10 @@ func (e *rpcClientError) Error() string {
 type Client struct {
 	bURL   string
 	client *http.Client
+}
+
+func normalizeBaseURL(baseURL string) string {
+	return strings.TrimRight(baseURL, "/") + "/"
 }
 
 func (c Client) DoRequest(ctx context.Context, method string, args, result any) error {

--- a/lokerpc/client_test.go
+++ b/lokerpc/client_test.go
@@ -1,0 +1,44 @@
+package lokerpc
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestNewClientNormalizesBaseURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		baseURL  string
+		expected string
+	}{
+		{
+			name:     "adds slash when missing",
+			baseURL:  "http://example.com/rpc/service",
+			expected: "http://example.com/rpc/service/",
+		},
+		{
+			name:     "keeps single trailing slash",
+			baseURL:  "http://example.com/rpc/service/",
+			expected: "http://example.com/rpc/service/",
+		},
+		{
+			name:     "collapses multiple trailing slashes",
+			baseURL:  "http://example.com/rpc/service///",
+			expected: "http://example.com/rpc/service/",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			c := newClientWithClient(tc.baseURL, http.DefaultClient)
+			if c.bURL != tc.expected {
+				t.Fatalf("expected normalized base URL %q, got %q", tc.expected, c.bURL)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Internal change only

This pull request improves the handling of base URLs in the `lokerpc` client by ensuring they are consistently normalized. It introduces a utility function to standardize base URLs and adds comprehensive tests to verify this behavior.

## Submitter Checklist

Check only those that apply to this change.

- [x] Self-reviewed code, removed extraneous comments, debug logging, checked code style
- [ ] No change to users after merge (off-by-default configuration, feature flag, alt URL, etc.) and can be disabled if issues arise (if this is not the case we may need stakeholder signoff)
- [ ] Changes are documented (README, wiki, etc)
- [ ] Automated tests added or existing tests cover the new functionality or changes
- [x] Manually tested changes
- [ ] Metrics added to track the usage/performance
- [x] I am confident I can revert this change
- [ ] Database migrations are reversible without data loss (if applicable)
- [ ] Performance impact is acceptable (if applicable)
- [ ] Any new dependencies are justified or have been approved (if applicable)
- [x] **This is NOT a high risk change** (if it is, please follow the high-risk change process)

### Testing Evidence

What evidence supports that you have tested this change?

- [x] Test cases cover the new functionality or changes
- [ ] Screenshots or logs of the changes (if applicable)
- [ ] Performance benchmarks (if applicable)
- [ ] Storybook cases (if applicable)

## Reviewer Checklist

Note: if this PR affects authentication or payments please seek a secondary tester.

- [ ] I am ok with code style and functionality
- [ ] I have personally tested the feature
- [ ] My review was not rushed due to time constraints
