### PR TITLE
Include time package in codegen

### DIFF
--- a/lokerpc/codegen/go.go
+++ b/lokerpc/codegen/go.go
@@ -86,6 +86,9 @@ func GenGoClient(w io.Writer, meta lokerpc.Meta) error {
 	b.WriteString("\n")
 	b.WriteString("import (\n")
 	b.WriteString("\t\"context\"\n")
+	if metaUsesTimestamp(meta) {
+		b.WriteString("\t\"time\"\n")
+	}
 	b.WriteString("\n")
 	b.WriteString("\t\"github.com/LOKE/pkg/lokerpc\"\n")
 	b.WriteString(")\n")
@@ -169,6 +172,51 @@ func GenGoClient(w io.Writer, meta lokerpc.Meta) error {
 	}
 
 	return b.Flush()
+}
+
+func schemaUsesTimestamp(schema jtd.Schema) bool {
+	if schema.Type == jtd.TypeTimestamp {
+		return true
+	}
+	for _, v := range schema.Definitions {
+		if schemaUsesTimestamp(v) {
+			return true
+		}
+	}
+	for _, v := range schema.Properties {
+		if schemaUsesTimestamp(v) {
+			return true
+		}
+	}
+	for _, v := range schema.OptionalProperties {
+		if schemaUsesTimestamp(v) {
+			return true
+		}
+	}
+	if schema.Elements != nil && schemaUsesTimestamp(*schema.Elements) {
+		return true
+	}
+	if schema.Values != nil && schemaUsesTimestamp(*schema.Values) {
+		return true
+	}
+	return false
+}
+
+func metaUsesTimestamp(meta lokerpc.Meta) bool {
+	for _, v := range meta.Definitions {
+		if schemaUsesTimestamp(v) {
+			return true
+		}
+	}
+	for _, iface := range meta.Interfaces {
+		if iface.RequestTypeDef != nil && schemaUsesTimestamp(*iface.RequestTypeDef) {
+			return true
+		}
+		if iface.ResponseTypeDef != nil && schemaUsesTimestamp(*iface.ResponseTypeDef) {
+			return true
+		}
+	}
+	return false
 }
 
 // Regexp that matches word boundaries,

--- a/lokerpc/codegen/testdata/nested.json.go
+++ b/lokerpc/codegen/testdata/nested.json.go
@@ -2,6 +2,7 @@ package nested
 
 import (
 	"context"
+	"time"
 
 	"github.com/LOKE/pkg/lokerpc"
 )


### PR DESCRIPTION
Internal change only

This update makes it so that it'll actually include the time package import when generating the go code

## Submitter Checklist

Check only those that apply to this change.

- [x] Self-reviewed code, removed extraneous comments, debug logging, checked code style
- [x] No change to users after merge (off-by-default configuration, feature flag, alt URL, etc.) and can be disabled if issues arise (if this is not the case we may need stakeholder signoff)
- [ ] Changes are documented (README, wiki, etc)
- [x] Automated tests added or existing tests cover the new functionality or changes
- [x] Manually tested changes
- [ ] Metrics added to track the usage/performance
- [x] I am confident I can revert this change
- [ ] Database migrations are reversible without data loss (if applicable)
- [ ] Performance impact is acceptable (if applicable)
- [ ] Any new dependencies are justified or have been approved (if applicable)
- [x] **This is NOT a high risk change** (if it is, please follow the high-risk change process)

### Testing Evidence

What evidence supports that you have tested this change?

- [x] Test cases cover the new functionality or changes
- [ ] Screenshots or logs of the changes (if applicable)
- [ ] Performance benchmarks (if applicable)
- [ ] Storybook cases (if applicable)

## Reviewer Checklist

Note: if this PR affects authentication or payments please seek a secondary tester.

- [ ] I am ok with code style and functionality
- [ ] I have personally tested the feature
- [ ] My review was not rushed due to time constraints
