### PR TITLE
refactor: make the rpc error struct public

### DIFF
--- a/lokerpc/client.go
+++ b/lokerpc/client.go
@@ -19,8 +19,8 @@ func newClientWithClient(baseURL string, client *http.Client) Client {
 	return Client{bURL: normalizeBaseURL(baseURL), client: client}
 }
 
-// NOTE: Maybe this should be exported, leaving it for now -- Dom
-type rpcClientError struct {
+// RPCError is the structured error returned by a remote RPC endpoint.
+type RPCError struct {
 	Message   string
 	Instance  string
 	Expose    bool
@@ -29,21 +29,24 @@ type rpcClientError struct {
 	Type      string
 }
 
-func (e *rpcClientError) ErrorID() string {
+func (e *RPCError) ErrorID() string {
 	return e.Instance
 }
 
-func (e *rpcClientError) ErrorType() string {
+func (e *RPCError) ErrorType() string {
 	return e.Type
 }
 
-func (e *rpcClientError) Public() bool {
+func (e *RPCError) ErrorCode() string {
+	return e.Code
+}
+
+func (e *RPCError) Public() bool {
 	return e.Expose
 }
 
-func (e *rpcClientError) Error() string {
+func (e *RPCError) Error() string {
 	return e.Message
-	// return fmt.Sprintf("RPC Error response: %s", e.Message)
 }
 
 type Client struct {
@@ -104,7 +107,7 @@ func (c Client) DoRequest(ctx context.Context, method string, args, result any) 
 	case http.StatusNotFound:
 		return fmt.Errorf("Error rpc method not found: %v", url)
 	default:
-		err := &rpcClientError{}
+		err := &RPCError{}
 		jsonErr := json.NewDecoder(res.Body).Decode(err)
 		if jsonErr != nil {
 			return fmt.Errorf("Error decoding rpc error response: %v", jsonErr)

--- a/lokerpc/server.go
+++ b/lokerpc/server.go
@@ -54,6 +54,11 @@ type Failer interface {
 	Failed() error
 }
 
+// Coder can be implemented by errors to include a machine-readable code in RPC error responses.
+type Coder interface {
+	ErrorCode() string
+}
+
 // Service
 type Service struct {
 	Name string
@@ -431,9 +436,14 @@ func makeHandler(logger log.Logger, ec EndpointCodec) http.HandlerFunc {
 			logErr("err", e.Failed())
 
 			status = http.StatusBadRequest
-			result = struct {
+			errResp := struct {
 				Message string `json:"message"`
-			}{e.Failed().Error()}
+				Code    string `json:"code,omitempty"`
+			}{Message: e.Failed().Error()}
+			if c, ok := e.Failed().(Coder); ok {
+				errResp.Code = c.ErrorCode()
+			}
+			result = errResp
 		} else {
 			if r, ok := result.(Resulter); ok {
 				result = r.Result()


### PR DESCRIPTION
Describe what this change means for non-engineering|Documentation only|Internal change only

[LOKE-XXXX]

Add any other details here about what this change does.

<!--
## Related PRs
- https://github.com/LOKE/example/pull/1
-->

<!--
## Rollback Instructions

-->

## Screenshots / Videos

##  I have:
- [ ] Run and tested the code and provided clear evidence of this above
- [ ] Self reviewed the code and removed extraneous comments, debug logging, checked code style
- [ ] Listed any dependant PRs required for this change
- [ ] Added tests where practical and possible
- [ ] Documented a way to roll this change back if it is more than a code revert

_all the above **must** be ticked_
