### PR TITLE
[MID-200] Add errors package

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: "1.26"
 
       - name: Test
         run: go test -v ./...

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/LOKE/pkg
 
-go 1.18
+go 1.26
 
 require (
 	github.com/go-kit/log v0.2.1

--- a/lokerpc/client.go
+++ b/lokerpc/client.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/LOKE/pkg/lokerr"
 	"github.com/LOKE/pkg/requestid"
 )
 
@@ -19,32 +20,6 @@ func newClientWithClient(baseURL string, client *http.Client) Client {
 	return Client{bURL: normalizeBaseURL(baseURL), client: client}
 }
 
-// NOTE: Maybe this should be exported, leaving it for now -- Dom
-type rpcClientError struct {
-	Message   string
-	Instance  string
-	Expose    bool
-	Code      string
-	Namespace string
-	Type      string
-}
-
-func (e *rpcClientError) ErrorID() string {
-	return e.Instance
-}
-
-func (e *rpcClientError) ErrorType() string {
-	return e.Type
-}
-
-func (e *rpcClientError) Public() bool {
-	return e.Expose
-}
-
-func (e *rpcClientError) Error() string {
-	return e.Message
-	// return fmt.Sprintf("RPC Error response: %s", e.Message)
-}
 
 type Client struct {
 	bURL   string
@@ -104,12 +79,11 @@ func (c Client) DoRequest(ctx context.Context, method string, args, result any) 
 	case http.StatusNotFound:
 		return fmt.Errorf("Error rpc method not found: %v", url)
 	default:
-		err := &rpcClientError{}
-		jsonErr := json.NewDecoder(res.Body).Decode(err)
-		if jsonErr != nil {
+		lErr := &lokerr.Error{}
+		if jsonErr := json.NewDecoder(res.Body).Decode(lErr); jsonErr != nil {
 			return fmt.Errorf("Error decoding rpc error response: %v", jsonErr)
 		}
-		return err
+		return lErr
 	}
 	return nil
 }

--- a/lokerpc/client.go
+++ b/lokerpc/client.go
@@ -79,7 +79,7 @@ func (c Client) DoRequest(ctx context.Context, method string, args, result any) 
 	case http.StatusNotFound:
 		return fmt.Errorf("Error rpc method not found: %v", url)
 	default:
-		lErr := &lokerr.Error{}
+		lErr := &lokerr.BaseError{}
 		if jsonErr := json.NewDecoder(res.Body).Decode(lErr); jsonErr != nil {
 			return fmt.Errorf("Error decoding rpc error response: %v", jsonErr)
 		}

--- a/lokerpc/server.go
+++ b/lokerpc/server.go
@@ -9,6 +9,7 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/LOKE/pkg/lokerr"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	jtd "github.com/jsontypedef/json-typedef-go"
@@ -428,12 +429,17 @@ func makeHandler(logger log.Logger, ec EndpointCodec) http.HandlerFunc {
 		status := http.StatusOK
 
 		if e, ok := result.(Failer); ok && e.Failed() != nil {
-			logErr("err", e.Failed())
+			failed := e.Failed()
+			logErr("err", failed)
 
 			status = http.StatusBadRequest
-			result = struct {
-				Message string `json:"message"`
-			}{e.Failed().Error()}
+			if lErr, ok := lokerr.As(failed); ok {
+				result = lErr
+			} else {
+				result = struct {
+					Message string `json:"message"`
+				}{failed.Error()}
+			}
 		} else {
 			if r, ok := result.(Resulter); ok {
 				result = r.Result()

--- a/lokerpc/server.go
+++ b/lokerpc/server.go
@@ -433,7 +433,7 @@ func makeHandler(logger log.Logger, ec EndpointCodec) http.HandlerFunc {
 			logErr("err", failed)
 
 			status = http.StatusBadRequest
-			if lErr, ok := lokerr.As(failed); ok {
+			if lErr, ok := failed.(lokerr.Error); ok {
 				result = lErr
 			} else {
 				result = struct {

--- a/lokerr/README.md
+++ b/lokerr/README.md
@@ -1,0 +1,147 @@
+# lokerr
+
+Structured, RPC-serializable errors for Go services. Wire-format compatible with the [`@loke/errors`](https://github.com/LOKE/errors) Node.js package.
+
+## Usage
+
+```go
+import "github.com/LOKE/pkg/lokerr"
+```
+
+### Creating errors
+
+```go
+// Public error — safe to display in a UI (expose: true)
+err := lokerr.New("The value provided was null.", "null_value")
+
+// Public error with formatted message
+err := lokerr.Errorf("validation_failed", "field %q is required", "email")
+
+// Internal error — logged only, not shown to users (expose: false)
+err := lokerr.Wrap(dbErr, "db_query_failed")
+
+// Internal error with a separate public message
+err := lokerr.WrapPublic(dbErr, "db_query_failed", "Something went wrong.")
+```
+
+### Optional fields
+
+```go
+err := lokerr.New("Payment declined.", "payment_declined")
+err.Namespace = "payments"
+err.Type = "https://example.com/errors/payments/payment_declined"
+err.Meta = map[string]any{"attemptCount": 3}
+```
+
+### Checking errors
+
+```go
+// Type-assert from any error in the chain
+if lErr, ok := lokerr.As(err); ok {
+    fmt.Println(lErr.ErrorCode(), lErr.ErrorID())
+}
+
+// Check if safe to show to end users
+if lokerr.IsPublic(err) {
+    respondWithMessage(w, err.Error())
+}
+
+// Standard Go error chain
+errors.Is(err, sentinel)
+errors.As(err, &target)
+```
+
+## Wire format
+
+Errors serialize to JSON compatible with `@loke/errors`:
+
+```json
+{
+  "instance": "a3f2c1...",
+  "message": "Payment declined.",
+  "code": "payment_declined",
+  "expose": true,
+  "namespace": "payments",
+  "type": "https://example.com/errors/payments/payment_declined",
+  "attemptCount": 3
+}
+```
+
+- `expose` is omitted when `false`
+- `code`, `namespace`, `type` are omitted when empty
+- `Meta` keys are flattened to the top level (struct fields take precedence over meta keys with the same name)
+- `instance` is always present — a random 32-char hex string generated at construction time
+
+## Reusable error types
+
+For errors that recur across a service, define constructor functions that pre-set the stable fields (`code`, `namespace`, `type`, `expose`) and accept only what varies at call time.
+
+```go
+// errors.go in your service package
+
+const typePrefix = "https://example.com/errors/payments/"
+
+func ErrPaymentDeclined(reason string) *lokerr.Error {
+    e := lokerr.New("Your payment was declined.", "payment_declined")
+    e.Namespace = "payments"
+    e.Type = typePrefix + "payment_declined"
+    e.Meta = map[string]any{"reason": reason}
+    return e
+}
+
+func ErrInsufficientFunds(available, required int64) *lokerr.Error {
+    e := lokerr.New("Insufficient funds.", "insufficient_funds")
+    e.Namespace = "payments"
+    e.Type = typePrefix + "insufficient_funds"
+    e.Meta = map[string]any{"available": available, "required": required}
+    return e
+}
+
+func ErrDBQuery(err error) *lokerr.Error {
+    return lokerr.WrapPublic(err, "db_query_failed", "Something went wrong.")
+}
+```
+
+### Matching reusable error types
+
+Each `lokerr.Error` has a unique `instance`, so `errors.Is` won't match across calls. Match on `ErrorCode()` or `Type` instead:
+
+```go
+if lErr, ok := lokerr.As(err); ok {
+    switch lErr.ErrorCode() {
+    case "payment_declined":
+        // handle declined
+    case "insufficient_funds":
+        // handle insufficient funds
+    }
+}
+```
+
+To support `errors.Is` matching, wrap a package-level sentinel:
+
+```go
+var ErrInsufficientFunds = errors.New("insufficient funds")
+
+func NewInsufficientFundsError(available, required int64) *lokerr.Error {
+    e := lokerr.WrapPublic(ErrInsufficientFunds, "insufficient_funds", "Insufficient funds.")
+    e.Namespace = "payments"
+    e.Type = typePrefix + "insufficient_funds"
+    e.Meta = map[string]any{"available": available, "required": required}
+    return e
+}
+
+// Caller can now use errors.Is:
+if errors.Is(err, ErrInsufficientFunds) { ... }
+```
+
+Note: the wrapped sentinel is never serialized — it is only present on the server side before the error crosses the wire. Deserialized errors on the client side will have `Unwrap() == nil`.
+
+## Public vs private errors
+
+| Constructor | `expose` | Use case |
+|---|---|---|
+| `New` / `Errorf` | `true` | User-facing validation errors, business rule violations |
+| `Wrap` | `false` | Internal failures (DB errors, network errors) — logged, not shown to users |
+| `WrapPublic` | `true` | Internal failure with a safe message to show the user |
+
+When a `lokerr.Error` reaches `lokerpc`, it is serialized in full (all fields) at HTTP 400. Plain Go errors produce `{"message":"..."}` for backward compatibility.

--- a/lokerr/README.md
+++ b/lokerr/README.md
@@ -30,7 +30,6 @@ err := lokerr.WrapPublic(dbErr, "db_query_failed", "Something went wrong.")
 err := lokerr.New("Payment declined.", "payment_declined")
 err.Namespace = "payments"
 err.Type = "https://example.com/errors/payments/payment_declined"
-err.Meta = map[string]any{"attemptCount": 3}
 ```
 
 ### Checking errors
@@ -38,7 +37,7 @@ err.Meta = map[string]any{"attemptCount": 3}
 ```go
 // Type-assert from any error in the chain
 if lErr, ok := lokerr.As(err); ok {
-    fmt.Println(lErr.ErrorCode(), lErr.ErrorID())
+    fmt.Println(lErr.ErrorCode())
 }
 
 // Check if safe to show to end users
@@ -57,84 +56,16 @@ Errors serialize to JSON compatible with `@loke/errors`:
 
 ```json
 {
-  "instance": "a3f2c1...",
   "message": "Payment declined.",
   "code": "payment_declined",
   "expose": true,
   "namespace": "payments",
-  "type": "https://example.com/errors/payments/payment_declined",
-  "attemptCount": 3
+  "type": "https://example.com/errors/payments/payment_declined"
 }
 ```
 
 - `expose` is omitted when `false`
 - `code`, `namespace`, `type` are omitted when empty
-- `Meta` keys are flattened to the top level (struct fields take precedence over meta keys with the same name)
-- `instance` is always present — a random 32-char hex string generated at construction time
-
-## Reusable error types
-
-For errors that recur across a service, define constructor functions that pre-set the stable fields (`code`, `namespace`, `type`, `expose`) and accept only what varies at call time.
-
-```go
-// errors.go in your service package
-
-const typePrefix = "https://example.com/errors/payments/"
-
-func ErrPaymentDeclined(reason string) *lokerr.Error {
-    e := lokerr.New("Your payment was declined.", "payment_declined")
-    e.Namespace = "payments"
-    e.Type = typePrefix + "payment_declined"
-    e.Meta = map[string]any{"reason": reason}
-    return e
-}
-
-func ErrInsufficientFunds(available, required int64) *lokerr.Error {
-    e := lokerr.New("Insufficient funds.", "insufficient_funds")
-    e.Namespace = "payments"
-    e.Type = typePrefix + "insufficient_funds"
-    e.Meta = map[string]any{"available": available, "required": required}
-    return e
-}
-
-func ErrDBQuery(err error) *lokerr.Error {
-    return lokerr.WrapPublic(err, "db_query_failed", "Something went wrong.")
-}
-```
-
-### Matching reusable error types
-
-Each `lokerr.Error` has a unique `instance`, so `errors.Is` won't match across calls. Match on `ErrorCode()` or `Type` instead:
-
-```go
-if lErr, ok := lokerr.As(err); ok {
-    switch lErr.ErrorCode() {
-    case "payment_declined":
-        // handle declined
-    case "insufficient_funds":
-        // handle insufficient funds
-    }
-}
-```
-
-To support `errors.Is` matching, wrap a package-level sentinel:
-
-```go
-var ErrInsufficientFunds = errors.New("insufficient funds")
-
-func NewInsufficientFundsError(available, required int64) *lokerr.Error {
-    e := lokerr.WrapPublic(ErrInsufficientFunds, "insufficient_funds", "Insufficient funds.")
-    e.Namespace = "payments"
-    e.Type = typePrefix + "insufficient_funds"
-    e.Meta = map[string]any{"available": available, "required": required}
-    return e
-}
-
-// Caller can now use errors.Is:
-if errors.Is(err, ErrInsufficientFunds) { ... }
-```
-
-Note: the wrapped sentinel is never serialized — it is only present on the server side before the error crosses the wire. Deserialized errors on the client side will have `Unwrap() == nil`.
 
 ## Public vs private errors
 
@@ -145,3 +76,99 @@ Note: the wrapped sentinel is never serialized — it is only present on the ser
 | `WrapPublic` | `true` | Internal failure with a safe message to show the user |
 
 When a `lokerr.Error` reaches `lokerpc`, it is serialized in full (all fields) at HTTP 400. Plain Go errors produce `{"message":"..."}` for backward compatibility.
+
+## Reusable error types
+
+For errors that recur across a service, define constructor functions that pre-set the stable fields (`code`, `namespace`, `type`, `expose`) and accept only what varies at call time.
+
+```go
+const typePrefix = "https://example.com/errors/payments/"
+
+func ErrPaymentDeclined() *lokerr.Error {
+    e := lokerr.New("Your payment was declined.", "payment_declined")
+    e.Namespace = "payments"
+    e.Type = typePrefix + "payment_declined"
+    return e
+}
+
+func ErrDBQuery(err error) *lokerr.Error {
+    return lokerr.WrapPublic(err, "db_query_failed", "Something went wrong.")
+}
+```
+
+### Matching reusable error types
+
+Match on `ErrorCode()` or wrap a package-level sentinel for `errors.Is` support:
+
+```go
+// Match by code
+if lErr, ok := lokerr.As(err); ok {
+    switch lErr.ErrorCode() {
+    case "payment_declined":
+        // handle
+    }
+}
+
+// Or wrap a sentinel so errors.Is works
+var ErrPaymentDeclined = errors.New("payment declined")
+
+func NewPaymentDeclinedError() *lokerr.Error {
+    e := lokerr.WrapPublic(ErrPaymentDeclined, "payment_declined", "Your payment was declined.")
+    e.Namespace = "payments"
+    return e
+}
+
+if errors.Is(err, ErrPaymentDeclined) { ... }
+```
+
+Note: the wrapped sentinel is never serialized — it is only present server-side before the error crosses the wire.
+
+## Extending the error type
+
+`lokerr.Error` is intentionally minimal. If a specific situation calls for extra fields (correlation IDs, structured metadata), embed it in your own type — the standard JSON encoder will merge the fields automatically.
+
+### Adding a correlation ID
+
+```go
+type TracedError struct {
+    *lokerr.Error
+    RequestID string `json:"requestId,omitempty"`
+}
+
+// Wire format: {"message":"...","code":"...","requestId":"abc123"}
+func NewTracedError(msg, code, requestID string) *TracedError {
+    return &TracedError{
+        Error:     lokerr.New(msg, code),
+        RequestID: requestID,
+    }
+}
+```
+
+### Adding typed metadata
+
+Rather than a generic map, define explicit fields so the wire format stays self-documenting:
+
+```go
+type ValidationError struct {
+    *lokerr.Error
+    Field  string `json:"field"`
+    Reason string `json:"reason,omitempty"`
+}
+
+// Wire format: {"message":"...","code":"validation_failed","field":"email","reason":"invalid format"}
+func NewValidationError(field, reason string) *ValidationError {
+    return &ValidationError{
+        Error:  lokerr.New("Validation failed.", "validation_failed"),
+        Field:  field,
+        Reason: reason,
+    }
+}
+```
+
+`lokerr.As` still works on embedded types since `*lokerr.Error` is in the chain:
+
+```go
+if lErr, ok := lokerr.As(err); ok {
+    // lErr is the embedded *lokerr.Error
+}
+```

--- a/lokerr/README.md
+++ b/lokerr/README.md
@@ -2,29 +2,41 @@
 
 Structured, RPC-serializable errors for Go services. Wire-format compatible with the [`@loke/errors`](https://github.com/LOKE/errors) Node.js package.
 
-## Usage
+## Design
+
+`lokerr` is interface-based. The `lokerr.Error` interface is what `lokerpc` and application code work against — any struct that implements it will be serialized in full over RPC. `BaseError` is provided as a convenience type for straightforward cases; define your own struct when you need extra fields.
+
+## The interface
+
+```go
+type Error interface {
+    error
+    Public() bool      // true = safe to show in a UI; false = log only
+    ErrorCode() string // machine-readable code, e.g. "validation_failed"
+}
+```
+
+Any type implementing these three methods integrates with `lokerpc` automatically.
+
+## Using BaseError
 
 ```go
 import "github.com/LOKE/pkg/lokerr"
-```
 
-### Creating errors
-
-```go
-// Public error — safe to display in a UI (expose: true)
+// Public error — expose: true, safe to show in a UI
 err := lokerr.New("The value provided was null.", "null_value")
 
 // Public error with formatted message
 err := lokerr.Errorf("validation_failed", "field %q is required", "email")
 
-// Internal error — logged only, not shown to users (expose: false)
+// Internal error — expose: false, logged but not shown to users
 err := lokerr.Wrap(dbErr, "db_query_failed")
 
-// Internal error with a separate public message
+// Internal error with a separate safe public message
 err := lokerr.WrapPublic(dbErr, "db_query_failed", "Something went wrong.")
 ```
 
-### Optional fields
+Optional fields on `BaseError`:
 
 ```go
 err := lokerr.New("Payment declined.", "payment_declined")
@@ -32,27 +44,88 @@ err.Namespace = "payments"
 err.Type = "https://example.com/errors/payments/payment_declined"
 ```
 
-### Checking errors
+## Custom error types
+
+When an error needs extra fields on the wire, embed `*lokerr.BaseError` and add your own exported fields. `lokerpc` serializes the concrete type directly, so the promoted `BaseError` fields and your custom fields all appear at the top level.
 
 ```go
-// Type-assert from any error in the chain
+type ValidationError struct {
+    *lokerr.BaseError
+    Field string `json:"field"`
+}
+
+func NewValidationError(field string) *ValidationError {
+    return &ValidationError{
+        BaseError: lokerr.New("Validation failed.", "validation_failed"),
+        Field:       field,
+    }
+}
+```
+
+Wire output:
+
+```json
+{"message":"Validation failed.","code":"validation_failed","expose":true,"field":"email"}
+```
+
+The same pattern works for any additional context — amounts, limits, resource IDs — just add exported fields with JSON tags.
+
+## Reusable error definitions
+
+Define constructor functions that fix the stable fields and accept only what varies per call:
+
+```go
+const typePrefix = "https://example.com/errors/payments/"
+
+func ErrPaymentDeclined() *lokerr.BaseError {
+    e := lokerr.New("Your payment was declined.", "payment_declined")
+    e.Namespace = "payments"
+    e.Type = typePrefix + "payment_declined"
+    return e
+}
+
+func ErrDBQuery(err error) *lokerr.BaseError {
+    return lokerr.WrapPublic(err, "db_query_failed", "Something went wrong.")
+}
+```
+
+To support `errors.Is` matching, wrap a package-level sentinel:
+
+```go
+var ErrInsufficientFunds = errors.New("insufficient funds")
+
+func NewInsufficientFundsError() *lokerr.BaseError {
+    e := lokerr.WrapPublic(ErrInsufficientFunds, "insufficient_funds", "Insufficient funds.")
+    e.Namespace = "payments"
+    return e
+}
+
+// Caller:
+if errors.Is(err, ErrInsufficientFunds) { ... }
+```
+
+Note: the wrapped sentinel is never serialized — it is only present server-side before the error crosses the wire.
+
+## Helper functions
+
+```go
+// Extract the lokerr.Error interface from any error in the chain
 if lErr, ok := lokerr.As(err); ok {
     fmt.Println(lErr.ErrorCode())
 }
 
-// Check if safe to show to end users
+// Check expose flag without a type assertion
 if lokerr.IsPublic(err) {
-    respondWithMessage(w, err.Error())
+    respondToUser(w, err.Error())
 }
 
-// Standard Go error chain
-errors.Is(err, sentinel)
-errors.As(err, &target)
+// Extract code from any error (returns "" if not a lokerr.Error)
+code := lokerr.ErrorCode(err)
 ```
 
 ## Wire format
 
-Errors serialize to JSON compatible with `@loke/errors`:
+`BaseError` serializes to JSON compatible with `@loke/errors`:
 
 ```json
 {
@@ -66,109 +139,10 @@ Errors serialize to JSON compatible with `@loke/errors`:
 
 - `expose` is omitted when `false`
 - `code`, `namespace`, `type` are omitted when empty
+- Custom types serialize their own exported fields alongside or instead of these
 
-## Public vs private errors
+## lokerpc integration
 
-| Constructor | `expose` | Use case |
-|---|---|---|
-| `New` / `Errorf` | `true` | User-facing validation errors, business rule violations |
-| `Wrap` | `false` | Internal failures (DB errors, network errors) — logged, not shown to users |
-| `WrapPublic` | `true` | Internal failure with a safe message to show the user |
+When a `lokerr.Error` is returned from an RPC handler, `lokerpc` serializes the concrete type in full at HTTP 400. Plain Go errors fall back to `{"message":"..."}` for backward compatibility.
 
-When a `lokerr.Error` reaches `lokerpc`, it is serialized in full (all fields) at HTTP 400. Plain Go errors produce `{"message":"..."}` for backward compatibility.
-
-## Reusable error types
-
-For errors that recur across a service, define constructor functions that pre-set the stable fields (`code`, `namespace`, `type`, `expose`) and accept only what varies at call time.
-
-```go
-const typePrefix = "https://example.com/errors/payments/"
-
-func ErrPaymentDeclined() *lokerr.Error {
-    e := lokerr.New("Your payment was declined.", "payment_declined")
-    e.Namespace = "payments"
-    e.Type = typePrefix + "payment_declined"
-    return e
-}
-
-func ErrDBQuery(err error) *lokerr.Error {
-    return lokerr.WrapPublic(err, "db_query_failed", "Something went wrong.")
-}
-```
-
-### Matching reusable error types
-
-Match on `ErrorCode()` or wrap a package-level sentinel for `errors.Is` support:
-
-```go
-// Match by code
-if lErr, ok := lokerr.As(err); ok {
-    switch lErr.ErrorCode() {
-    case "payment_declined":
-        // handle
-    }
-}
-
-// Or wrap a sentinel so errors.Is works
-var ErrPaymentDeclined = errors.New("payment declined")
-
-func NewPaymentDeclinedError() *lokerr.Error {
-    e := lokerr.WrapPublic(ErrPaymentDeclined, "payment_declined", "Your payment was declined.")
-    e.Namespace = "payments"
-    return e
-}
-
-if errors.Is(err, ErrPaymentDeclined) { ... }
-```
-
-Note: the wrapped sentinel is never serialized — it is only present server-side before the error crosses the wire.
-
-## Extending the error type
-
-`lokerr.Error` is intentionally minimal. If a specific situation calls for extra fields (correlation IDs, structured metadata), embed it in your own type — the standard JSON encoder will merge the fields automatically.
-
-### Adding a correlation ID
-
-```go
-type TracedError struct {
-    *lokerr.Error
-    RequestID string `json:"requestId,omitempty"`
-}
-
-// Wire format: {"message":"...","code":"...","requestId":"abc123"}
-func NewTracedError(msg, code, requestID string) *TracedError {
-    return &TracedError{
-        Error:     lokerr.New(msg, code),
-        RequestID: requestID,
-    }
-}
-```
-
-### Adding typed metadata
-
-Rather than a generic map, define explicit fields so the wire format stays self-documenting:
-
-```go
-type ValidationError struct {
-    *lokerr.Error
-    Field  string `json:"field"`
-    Reason string `json:"reason,omitempty"`
-}
-
-// Wire format: {"message":"...","code":"validation_failed","field":"email","reason":"invalid format"}
-func NewValidationError(field, reason string) *ValidationError {
-    return &ValidationError{
-        Error:  lokerr.New("Validation failed.", "validation_failed"),
-        Field:  field,
-        Reason: reason,
-    }
-}
-```
-
-`lokerr.As` still works on embedded types since `*lokerr.Error` is in the chain:
-
-```go
-if lErr, ok := lokerr.As(err); ok {
-    // lErr is the embedded *lokerr.Error
-}
-```
+On the client side, error responses are deserialized into `*lokerr.BaseError`, giving access to `Public()`, `ErrorCode()`, and `Error()`.

--- a/lokerr/README.md
+++ b/lokerr/README.md
@@ -26,9 +26,6 @@ import "github.com/LOKE/pkg/lokerr"
 // Public error — expose: true, safe to show in a UI
 err := lokerr.New("The value provided was null.", "null_value")
 
-// Public error with formatted message
-err := lokerr.Errorf("validation_failed", "field %q is required", "email")
-
 // Internal error — expose: false, logged but not shown to users
 err := lokerr.Wrap(dbErr, "db_query_failed")
 

--- a/lokerr/errors.go
+++ b/lokerr/errors.go
@@ -1,0 +1,96 @@
+package lokerr
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// Error is a structured error that serializes to the @loke/errors wire format.
+type Error struct {
+	Message   string         `json:"message"`
+	Code      string         `json:"code,omitempty"`
+	Instance  string         `json:"instance"`
+	Expose    bool           `json:"expose,omitempty"`
+	Namespace string         `json:"namespace,omitempty"`
+	Type      string         `json:"type,omitempty"`
+	Meta      map[string]any `json:"-"`
+	wrapped   error
+}
+
+func (e *Error) Error() string     { return e.Message }
+func (e *Error) Public() bool      { return e.Expose }
+func (e *Error) ErrorCode() string { return e.Code }
+func (e *Error) ErrorID() string   { return e.Instance }
+func (e *Error) Unwrap() error     { return e.wrapped }
+
+// MarshalJSON flattens Meta keys at the top level, matching @loke/errors behavior.
+// Struct fields always win over Meta keys in case of conflict.
+func (e *Error) MarshalJSON() ([]byte, error) {
+	m := make(map[string]any, len(e.Meta)+7)
+	for k, v := range e.Meta {
+		m[k] = v
+	}
+	m["message"] = e.Message
+	m["instance"] = e.Instance
+	if e.Code != "" {
+		m["code"] = e.Code
+	}
+	if e.Expose {
+		m["expose"] = e.Expose
+	}
+	if e.Namespace != "" {
+		m["namespace"] = e.Namespace
+	}
+	if e.Type != "" {
+		m["type"] = e.Type
+	}
+	return json.Marshal(m)
+}
+
+// New creates a public error (Expose=true).
+func New(msg, code string) *Error {
+	return &Error{Message: msg, Code: code, Instance: newID(), Expose: true}
+}
+
+// Errorf creates a public error with a formatted message.
+func Errorf(code, format string, args ...any) *Error {
+	return &Error{Message: fmt.Sprintf(format, args...), Code: code, Instance: newID(), Expose: true}
+}
+
+// Wrap wraps an internal error. Expose is false — not safe to show to end users.
+// If err is nil, returns a non-public error with the given code.
+func Wrap(err error, code string) *Error {
+	if err == nil {
+		return &Error{Message: "unknown error", Code: code, Instance: newID()}
+	}
+	return &Error{Message: err.Error(), Code: code, Instance: newID(), wrapped: err}
+}
+
+// WrapPublic wraps an internal error with a safe public message.
+// Expose is true — publicMsg is safe to show to end users.
+func WrapPublic(err error, code, publicMsg string) *Error {
+	return &Error{Message: publicMsg, Code: code, Instance: newID(), Expose: true, wrapped: err}
+}
+
+// As returns the *Error in the error chain, if any.
+func As(err error) (*Error, bool) {
+	var e *Error
+	return e, errors.As(err, &e)
+}
+
+// IsPublic reports whether err or any error in its chain is a public lokerr.Error.
+func IsPublic(err error) bool {
+	e, ok := As(err)
+	return ok && e.Expose
+}
+
+func newID() string {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		panic(err)
+	}
+	return hex.EncodeToString(b)
+}

--- a/lokerr/errors.go
+++ b/lokerr/errors.go
@@ -1,78 +1,48 @@
 package lokerr
 
 import (
-	"crypto/rand"
-	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
 )
 
 // Error is a structured error that serializes to the @loke/errors wire format.
 type Error struct {
-	Message   string         `json:"message"`
-	Code      string         `json:"code,omitempty"`
-	Instance  string         `json:"instance"`
-	Expose    bool           `json:"expose,omitempty"`
-	Namespace string         `json:"namespace,omitempty"`
-	Type      string         `json:"type,omitempty"`
-	Meta      map[string]any `json:"-"`
+	Message   string `json:"message"`
+	Code      string `json:"code,omitempty"`
+	Expose    bool   `json:"expose,omitempty"`
+	Namespace string `json:"namespace,omitempty"`
+	Type      string `json:"type,omitempty"`
 	wrapped   error
 }
 
 func (e *Error) Error() string     { return e.Message }
 func (e *Error) Public() bool      { return e.Expose }
 func (e *Error) ErrorCode() string { return e.Code }
-func (e *Error) ErrorID() string   { return e.Instance }
 func (e *Error) Unwrap() error     { return e.wrapped }
-
-// MarshalJSON flattens Meta keys at the top level, matching @loke/errors behavior.
-// Struct fields always win over Meta keys in case of conflict.
-func (e *Error) MarshalJSON() ([]byte, error) {
-	m := make(map[string]any, len(e.Meta)+7)
-	for k, v := range e.Meta {
-		m[k] = v
-	}
-	m["message"] = e.Message
-	m["instance"] = e.Instance
-	if e.Code != "" {
-		m["code"] = e.Code
-	}
-	if e.Expose {
-		m["expose"] = e.Expose
-	}
-	if e.Namespace != "" {
-		m["namespace"] = e.Namespace
-	}
-	if e.Type != "" {
-		m["type"] = e.Type
-	}
-	return json.Marshal(m)
-}
 
 // New creates a public error (Expose=true).
 func New(msg, code string) *Error {
-	return &Error{Message: msg, Code: code, Instance: newID(), Expose: true}
+	return &Error{Message: msg, Code: code, Expose: true}
 }
 
 // Errorf creates a public error with a formatted message.
 func Errorf(code, format string, args ...any) *Error {
-	return &Error{Message: fmt.Sprintf(format, args...), Code: code, Instance: newID(), Expose: true}
+	return &Error{Message: fmt.Sprintf(format, args...), Code: code, Expose: true}
 }
 
 // Wrap wraps an internal error. Expose is false — not safe to show to end users.
 // If err is nil, returns a non-public error with the given code.
 func Wrap(err error, code string) *Error {
 	if err == nil {
-		return &Error{Message: "unknown error", Code: code, Instance: newID()}
+		return &Error{Message: "unknown error", Code: code}
 	}
-	return &Error{Message: err.Error(), Code: code, Instance: newID(), wrapped: err}
+	return &Error{Message: err.Error(), Code: code, wrapped: err}
 }
 
 // WrapPublic wraps an internal error with a safe public message.
 // Expose is true — publicMsg is safe to show to end users.
 func WrapPublic(err error, code, publicMsg string) *Error {
-	return &Error{Message: publicMsg, Code: code, Instance: newID(), Expose: true, wrapped: err}
+	return &Error{Message: publicMsg, Code: code, Expose: true, wrapped: err}
 }
 
 // As returns the *Error in the error chain, if any.
@@ -85,12 +55,4 @@ func As(err error) (*Error, bool) {
 func IsPublic(err error) bool {
 	e, ok := As(err)
 	return ok && e.Expose
-}
-
-func newID() string {
-	b := make([]byte, 16)
-	if _, err := rand.Read(b); err != nil {
-		panic(err)
-	}
-	return hex.EncodeToString(b)
 }

--- a/lokerr/errors.go
+++ b/lokerr/errors.go
@@ -14,9 +14,11 @@ type Error interface {
 
 // ErrorCode returns the error code of the first error in err's chain that implements ErrorCode(), otherwise "".
 func ErrorCode(err error) string {
-	type coder interface{ ErrorCode() string }
-	var e coder
-	if errors.As(err, &e) {
+	type coder interface {
+		error
+		ErrorCode() string
+	}
+	if e, ok := errors.AsType[coder](err); ok {
 		return e.ErrorCode()
 	}
 	return ""
@@ -24,15 +26,15 @@ func ErrorCode(err error) string {
 
 // IsPublic reports whether any error in err's chain implements lokerr.Error and is marked as public.
 func IsPublic(err error) bool {
-	var e Error
-	return errors.As(err, &e) && e.Public()
+	if e, ok := errors.AsType[Error](err); ok {
+		return e.Public()
+	}
+	return false
 }
 
 // As returns the first lokerr.Error in err's chain, if any.
 func As(err error) (Error, bool) {
-	var e Error
-	ok := errors.As(err, &e)
-	return e, ok
+	return errors.AsType[Error](err)
 }
 
 // BaseError is a convenience type implementing Error.

--- a/lokerr/errors.go
+++ b/lokerr/errors.go
@@ -5,8 +5,39 @@ import (
 	"fmt"
 )
 
-// Error is a structured error that serializes to the @loke/errors wire format.
-type Error struct {
+// Error is the interface for structured, serializable RPC errors.
+// Any type implementing this interface is serialized in full by lokerpc.
+type Error interface {
+	error
+	Public() bool
+	ErrorCode() string
+}
+
+// ErrorCode returns the error code of err if it implements ErrorCode(), otherwise "".
+func ErrorCode(err error) string {
+	type coder interface{ ErrorCode() string }
+	if e, ok := err.(coder); ok {
+		return e.ErrorCode()
+	}
+	return ""
+}
+
+// IsPublic reports whether err implements lokerr.Error and is marked as public.
+func IsPublic(err error) bool {
+	e, ok := err.(Error)
+	return ok && e.Public()
+}
+
+// As returns the first lokerr.Error in err's chain, if any.
+func As(err error) (Error, bool) {
+	var e Error
+	ok := errors.As(err, &e)
+	return e, ok
+}
+
+// BaseError is a convenience type implementing Error.
+// For errors that require additional wire fields, embed *BaseError in a custom struct — see README.
+type BaseError struct {
 	Message   string `json:"message"`
 	Code      string `json:"code,omitempty"`
 	Expose    bool   `json:"expose,omitempty"`
@@ -15,44 +46,31 @@ type Error struct {
 	wrapped   error
 }
 
-func (e *Error) Error() string     { return e.Message }
-func (e *Error) Public() bool      { return e.Expose }
-func (e *Error) ErrorCode() string { return e.Code }
-func (e *Error) Unwrap() error     { return e.wrapped }
+func (e *BaseError) Error() string     { return e.Message }
+func (e *BaseError) Public() bool      { return e.Expose }
+func (e *BaseError) ErrorCode() string { return e.Code }
+func (e *BaseError) Unwrap() error     { return e.wrapped }
 
-// New creates a public error (Expose=true).
-func New(msg, code string) *Error {
-	return &Error{Message: msg, Code: code, Expose: true}
+// New creates a public BaseError (Expose=true).
+func New(msg, code string) *BaseError {
+	return &BaseError{Message: msg, Code: code, Expose: true}
 }
 
-// Errorf creates a public error with a formatted message.
-func Errorf(code, format string, args ...any) *Error {
-	return &Error{Message: fmt.Sprintf(format, args...), Code: code, Expose: true}
+// Errorf creates a public BaseError with a formatted message.
+func Errorf(code, format string, args ...any) *BaseError {
+	return &BaseError{Message: fmt.Sprintf(format, args...), Code: code, Expose: true}
 }
 
-// Wrap wraps an internal error. Expose is false — not safe to show to end users.
-// If err is nil, returns a non-public error with the given code.
-func Wrap(err error, code string) *Error {
+// Wrap wraps an internal error as a non-public BaseError (Expose=false).
+// If err is nil, returns a non-public error with message "unknown error".
+func Wrap(err error, code string) *BaseError {
 	if err == nil {
-		return &Error{Message: "unknown error", Code: code}
+		return &BaseError{Message: "unknown error", Code: code}
 	}
-	return &Error{Message: err.Error(), Code: code, wrapped: err}
+	return &BaseError{Message: err.Error(), Code: code, wrapped: err}
 }
 
-// WrapPublic wraps an internal error with a safe public message.
-// Expose is true — publicMsg is safe to show to end users.
-func WrapPublic(err error, code, publicMsg string) *Error {
-	return &Error{Message: publicMsg, Code: code, Expose: true, wrapped: err}
-}
-
-// As returns the *Error in the error chain, if any.
-func As(err error) (*Error, bool) {
-	var e *Error
-	return e, errors.As(err, &e)
-}
-
-// IsPublic reports whether err or any error in its chain is a public lokerr.Error.
-func IsPublic(err error) bool {
-	e, ok := As(err)
-	return ok && e.Expose
+// WrapPublic wraps an internal error with a safe public message (Expose=true).
+func WrapPublic(err error, code, publicMsg string) *BaseError {
+	return &BaseError{Message: publicMsg, Code: code, Expose: true, wrapped: err}
 }

--- a/lokerr/errors.go
+++ b/lokerr/errors.go
@@ -2,7 +2,6 @@ package lokerr
 
 import (
 	"errors"
-	"fmt"
 )
 
 // Error is the interface for structured, serializable RPC errors.
@@ -54,11 +53,6 @@ func (e *BaseError) Unwrap() error     { return e.wrapped }
 // New creates a public BaseError (Expose=true).
 func New(msg, code string) *BaseError {
 	return &BaseError{Message: msg, Code: code, Expose: true}
-}
-
-// Errorf creates a public BaseError with a formatted message.
-func Errorf(code, format string, args ...any) *BaseError {
-	return &BaseError{Message: fmt.Sprintf(format, args...), Code: code, Expose: true}
 }
 
 // Wrap wraps an internal error as a non-public BaseError (Expose=false).

--- a/lokerr/errors.go
+++ b/lokerr/errors.go
@@ -12,19 +12,20 @@ type Error interface {
 	ErrorCode() string
 }
 
-// ErrorCode returns the error code of err if it implements ErrorCode(), otherwise "".
+// ErrorCode returns the error code of the first error in err's chain that implements ErrorCode(), otherwise "".
 func ErrorCode(err error) string {
 	type coder interface{ ErrorCode() string }
-	if e, ok := err.(coder); ok {
+	var e coder
+	if errors.As(err, &e) {
 		return e.ErrorCode()
 	}
 	return ""
 }
 
-// IsPublic reports whether err implements lokerr.Error and is marked as public.
+// IsPublic reports whether any error in err's chain implements lokerr.Error and is marked as public.
 func IsPublic(err error) bool {
-	e, ok := err.(Error)
-	return ok && e.Public()
+	var e Error
+	return errors.As(err, &e) && e.Public()
 }
 
 // As returns the first lokerr.Error in err's chain, if any.

--- a/lokerr/errors_test.go
+++ b/lokerr/errors_test.go
@@ -29,9 +29,6 @@ func TestWireFormat(t *testing.T) {
 	if got["code"] != "validation_failed" {
 		t.Errorf("code = %v", got["code"])
 	}
-	if got["instance"] == "" || got["instance"] == nil {
-		t.Error("instance must be present and non-empty")
-	}
 	if got["expose"] != true {
 		t.Errorf("expose = %v, want true", got["expose"])
 	}
@@ -61,47 +58,6 @@ func TestExposeOmitEmpty(t *testing.T) {
 	}
 }
 
-func TestMetaFlattened(t *testing.T) {
-	e := lokerr.New("msg", "code")
-	e.Meta = map[string]any{"field": "username", "limit": 10}
-
-	b, err := json.Marshal(e)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	var got map[string]any
-	if err := json.Unmarshal(b, &got); err != nil {
-		t.Fatal(err)
-	}
-
-	if got["field"] != "username" {
-		t.Errorf("field = %v, want username", got["field"])
-	}
-	if got["limit"] != float64(10) {
-		t.Errorf("limit = %v, want 10", got["limit"])
-	}
-}
-
-func TestMetaConflictStructFieldWins(t *testing.T) {
-	e := lokerr.New("real message", "code")
-	e.Meta = map[string]any{"message": "fake message"}
-
-	b, err := json.Marshal(e)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	var got map[string]any
-	if err := json.Unmarshal(b, &got); err != nil {
-		t.Fatal(err)
-	}
-
-	if got["message"] != "real message" {
-		t.Errorf("message = %v, want real message (struct field must win)", got["message"])
-	}
-}
-
 func TestErrorChain(t *testing.T) {
 	sentinel := errors.New("original error")
 	wrapped := lokerr.Wrap(sentinel, "wrap_code")
@@ -120,33 +76,15 @@ func TestErrorChain(t *testing.T) {
 	}
 }
 
-func TestIDUnique(t *testing.T) {
-	a := lokerr.New("msg", "code")
-	b := lokerr.New("msg", "code")
-
-	if a.Instance == "" {
-		t.Error("Instance must be non-empty")
-	}
-	if a.Instance == b.Instance {
-		t.Error("Two New() calls must produce different Instance values")
-	}
-}
-
 func TestConstructorDefaults(t *testing.T) {
 	pub := lokerr.New("msg", "code")
 	if !pub.Expose {
 		t.Error("New must set Expose=true")
 	}
-	if pub.Instance == "" {
-		t.Error("New must set Instance")
-	}
 
 	internal := lokerr.Wrap(errors.New("inner"), "code")
 	if internal.Expose {
 		t.Error("Wrap must set Expose=false")
-	}
-	if internal.Instance == "" {
-		t.Error("Wrap must set Instance")
 	}
 
 	nilWrap := lokerr.Wrap(nil, "code")

--- a/lokerr/errors_test.go
+++ b/lokerr/errors_test.go
@@ -1,0 +1,182 @@
+package lokerr_test
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/LOKE/pkg/lokerr"
+)
+
+func TestWireFormat(t *testing.T) {
+	e := lokerr.New("Something went wrong", "validation_failed")
+	e.Type = "https://example.com/errors/validation_failed"
+	e.Namespace = "payments"
+
+	b, err := json.Marshal(e)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatal(err)
+	}
+
+	if got["message"] != "Something went wrong" {
+		t.Errorf("message = %v", got["message"])
+	}
+	if got["code"] != "validation_failed" {
+		t.Errorf("code = %v", got["code"])
+	}
+	if got["instance"] == "" || got["instance"] == nil {
+		t.Error("instance must be present and non-empty")
+	}
+	if got["expose"] != true {
+		t.Errorf("expose = %v, want true", got["expose"])
+	}
+	if got["type"] != "https://example.com/errors/validation_failed" {
+		t.Errorf("type = %v", got["type"])
+	}
+	if got["namespace"] != "payments" {
+		t.Errorf("namespace = %v", got["namespace"])
+	}
+}
+
+func TestExposeOmitEmpty(t *testing.T) {
+	e := lokerr.Wrap(errors.New("internal"), "some_code")
+
+	b, err := json.Marshal(e)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, present := got["expose"]; present {
+		t.Error("expose must be absent in JSON when false")
+	}
+}
+
+func TestMetaFlattened(t *testing.T) {
+	e := lokerr.New("msg", "code")
+	e.Meta = map[string]any{"field": "username", "limit": 10}
+
+	b, err := json.Marshal(e)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatal(err)
+	}
+
+	if got["field"] != "username" {
+		t.Errorf("field = %v, want username", got["field"])
+	}
+	if got["limit"] != float64(10) {
+		t.Errorf("limit = %v, want 10", got["limit"])
+	}
+}
+
+func TestMetaConflictStructFieldWins(t *testing.T) {
+	e := lokerr.New("real message", "code")
+	e.Meta = map[string]any{"message": "fake message"}
+
+	b, err := json.Marshal(e)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatal(err)
+	}
+
+	if got["message"] != "real message" {
+		t.Errorf("message = %v, want real message (struct field must win)", got["message"])
+	}
+}
+
+func TestErrorChain(t *testing.T) {
+	sentinel := errors.New("original error")
+	wrapped := lokerr.Wrap(sentinel, "wrap_code")
+
+	if !errors.Is(wrapped, sentinel) {
+		t.Error("errors.Is must find sentinel through wrapped chain")
+	}
+
+	var lErr *lokerr.Error
+	if !errors.As(wrapped, &lErr) {
+		t.Error("errors.As must find *lokerr.Error")
+	}
+
+	if errors.Unwrap(wrapped) != sentinel {
+		t.Error("errors.Unwrap must return sentinel")
+	}
+}
+
+func TestIDUnique(t *testing.T) {
+	a := lokerr.New("msg", "code")
+	b := lokerr.New("msg", "code")
+
+	if a.Instance == "" {
+		t.Error("Instance must be non-empty")
+	}
+	if a.Instance == b.Instance {
+		t.Error("Two New() calls must produce different Instance values")
+	}
+}
+
+func TestConstructorDefaults(t *testing.T) {
+	pub := lokerr.New("msg", "code")
+	if !pub.Expose {
+		t.Error("New must set Expose=true")
+	}
+	if pub.Instance == "" {
+		t.Error("New must set Instance")
+	}
+
+	internal := lokerr.Wrap(errors.New("inner"), "code")
+	if internal.Expose {
+		t.Error("Wrap must set Expose=false")
+	}
+	if internal.Instance == "" {
+		t.Error("Wrap must set Instance")
+	}
+
+	nilWrap := lokerr.Wrap(nil, "code")
+	if nilWrap.Message != "unknown error" {
+		t.Errorf("Wrap(nil) message = %v, want unknown error", nilWrap.Message)
+	}
+}
+
+func TestHelpers(t *testing.T) {
+	pub := lokerr.New("msg", "code")
+	priv := lokerr.Wrap(errors.New("inner"), "code")
+	plain := errors.New("plain")
+
+	e, ok := lokerr.As(pub)
+	if !ok || e == nil {
+		t.Error("As must find *Error for lokerr.New result")
+	}
+
+	_, ok = lokerr.As(plain)
+	if ok {
+		t.Error("As must return false for plain errors")
+	}
+
+	if !lokerr.IsPublic(pub) {
+		t.Error("IsPublic must return true for public error")
+	}
+	if lokerr.IsPublic(priv) {
+		t.Error("IsPublic must return false for non-public error")
+	}
+	if lokerr.IsPublic(plain) {
+		t.Error("IsPublic must return false for plain errors")
+	}
+}

--- a/lokerr/errors_test.go
+++ b/lokerr/errors_test.go
@@ -66,9 +66,9 @@ func TestErrorChain(t *testing.T) {
 		t.Error("errors.Is must find sentinel through wrapped chain")
 	}
 
-	var lErr *lokerr.Error
+	var lErr *lokerr.BaseError
 	if !errors.As(wrapped, &lErr) {
-		t.Error("errors.As must find *lokerr.Error")
+		t.Error("errors.As must find *lokerr.BaseError")
 	}
 
 	if errors.Unwrap(wrapped) != sentinel {
@@ -100,7 +100,7 @@ func TestHelpers(t *testing.T) {
 
 	e, ok := lokerr.As(pub)
 	if !ok || e == nil {
-		t.Error("As must find *Error for lokerr.New result")
+		t.Error("As must find lokerr.Error for lokerr.New result")
 	}
 
 	_, ok = lokerr.As(plain)
@@ -116,5 +116,49 @@ func TestHelpers(t *testing.T) {
 	}
 	if lokerr.IsPublic(plain) {
 		t.Error("IsPublic must return false for plain errors")
+	}
+
+	if lokerr.ErrorCode(pub) != "code" {
+		t.Errorf("ErrorCode = %v, want code", lokerr.ErrorCode(pub))
+	}
+	if lokerr.ErrorCode(plain) != "" {
+		t.Errorf("ErrorCode on plain error = %v, want empty", lokerr.ErrorCode(plain))
+	}
+}
+
+// customError demonstrates a user-defined type implementing lokerr.Error.
+type customError struct {
+	msg   string
+	code  string
+	Field string `json:"field"`
+}
+
+func (e *customError) Error() string     { return e.msg }
+func (e *customError) Public() bool      { return true }
+func (e *customError) ErrorCode() string { return e.code }
+
+func TestCustomTypeImplementsInterface(t *testing.T) {
+	err := &customError{msg: "field required", code: "required", Field: "email"}
+
+	var _ lokerr.Error = err // compile-time interface check
+
+	if !lokerr.IsPublic(err) {
+		t.Error("IsPublic must return true for custom public error")
+	}
+	if lokerr.ErrorCode(err) != "required" {
+		t.Errorf("ErrorCode = %v, want required", lokerr.ErrorCode(err))
+	}
+
+	// Custom field must serialize correctly
+	b, marshalErr := json.Marshal(err)
+	if marshalErr != nil {
+		t.Fatal(marshalErr)
+	}
+	var got map[string]any
+	if jsonErr := json.Unmarshal(b, &got); jsonErr != nil {
+		t.Fatal(jsonErr)
+	}
+	if got["field"] != "email" {
+		t.Errorf("field = %v, want email", got["field"])
 	}
 }


### PR DESCRIPTION
Internal change only

[MID-200]

Adds a new `lokerr` package providing structured, RPC-serializable errors compatible with the `@loke/errors` Node.js wire format. Integrates with `lokerpc` so the server serializes `lokerr.Error` in full and the client deserializes error responses directly into `*lokerr.Error`.

<!--
## Related PRs
- https://github.com/LOKE/example/pull/1
-->

<!--
## Rollback Instructions

-->

## Screenshots / Videos

<img width="1381" height="520" alt="image" src="https://github.com/user-attachments/assets/dbe084dd-b892-4391-93b9-fc9cc692e94a" />

^ shows an error with a code being taken and mapped into a different log to expose to customers

##  I have:
- [x] Run and tested the code and provided clear evidence of this above
- [x] Self reviewed the code and removed extraneous comments, debug logging, checked code style
- [x] Listed any dependant PRs required for this change
- [x] Added tests where practical and possible
- [x] Documented a way to roll this change back if it is more than a code revert

_all the above **must** be ticked_


[MID-200]: https://loke.atlassian.net/browse/MID-200?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ