### PR TITLE
Add support for public errors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: "1.26"
 
       - name: Test
         run: go test -v ./...

--- a/errors/error.go
+++ b/errors/error.go
@@ -1,0 +1,109 @@
+package errors
+
+import (
+	"errors"
+)
+
+// IsPublic returns the result of calling the Public method on err, if err's
+// type contains a Public method returning bool.
+// Otherwise, Public returns false.
+//
+// IsPublic only calls Public on the immediate error value, not on any wrapped
+// errors.
+func IsPublic(err error) bool {
+	p, ok := err.(interface {
+		Public() bool
+	})
+	if !ok {
+		return false
+	}
+	return p.Public()
+}
+
+// ErrorCode returns the result of calling the ErrorCode method on err, if err's
+// type contains an ErrorCode method returning string.
+// Otherwise, ErrorCode returns an empty string.
+//
+// ErrorCode only calls ErrorCode on the immediate error value, not on any
+// wrapped errors.
+func ErrorCode(err error) string {
+	c, ok := err.(interface {
+		ErrorCode() string
+	})
+	if !ok {
+		return ""
+	}
+	return c.ErrorCode()
+}
+
+// ErrorType returns the same thing as ErrorCode for now
+//
+// TODO: in the future we may want this to be richer the same way it is in
+// nodejs projects. That is <project_prefix>/<package>/<error_code>, eg.
+// `https://errors.loke.global//global-auth/clients/not_found`
+func ErrorType(err error) string {
+	return ErrorCode(err)
+}
+
+// NewPublicError returns a new public error with the given code and message.
+func NewPublicError(code string, message string) error {
+	return &publicError{
+		code:    code,
+		message: message,
+	}
+}
+
+// WrapWithPublicMessage wraps err with a public error that has the given code
+// and message.
+func WrapWithPublicMessage(err error, code string, message string) error {
+	return &publicError{
+		code:    code,
+		message: message,
+		inner:   err,
+	}
+}
+
+type publicError struct {
+	code    string
+	message string
+	inner   error
+}
+
+func (e *publicError) Public() bool {
+	return true
+}
+
+func (e *publicError) ErrorCode() string {
+	return e.code
+}
+
+func (e *publicError) Error() string {
+	return e.message
+}
+
+func (e *publicError) Unwrap() error {
+	return e.inner
+}
+
+// The following are re-exports of the standard library errors package. They are
+// here so that callers don't need to import the standard library errors
+// package, making it more ergonomic to use this as a drop-in replacement.
+//
+// We only re-export functions that are commonly used. Notably, we do not
+// re-export New as you would normally use fmt.Errorf instead. And we don't
+// export As because AsType should be used instead.
+
+// AsType is a re-export of [errors.AsType] for convenience.
+func AsType[E error](err error) (E, bool) {
+	return errors.AsType[E](err)
+}
+
+// Is is a re-export of [errors.Is] for convenience.
+func Is(err, target error) bool {
+	return errors.Is(err, target)
+}
+
+// Unwrap is a re-export of [errors.Unwrap] for convenience.
+func Unwrap(err error) error {
+	return errors.Unwrap(err)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/LOKE/pkg
 
-go 1.18
+go 1.26
 
 require (
 	github.com/go-kit/log v0.2.1

--- a/lokerpc/client.go
+++ b/lokerpc/client.go
@@ -20,7 +20,7 @@ func newClientWithClient(baseURL string, client *http.Client) Client {
 }
 
 // NOTE: Maybe this should be exported, leaving it for now -- Dom
-// Could also keep make this a map[string]any for passing through arbitrary fields
+// Could also make this a map[string]any for passing through arbitrary fields
 // to the upstream caller
 type rpcClientError struct {
 	Message   string `json:"message"`

--- a/lokerpc/client.go
+++ b/lokerpc/client.go
@@ -20,13 +20,15 @@ func newClientWithClient(baseURL string, client *http.Client) Client {
 }
 
 // NOTE: Maybe this should be exported, leaving it for now -- Dom
+// Could also keep make this a map[string]any for passing through arbitrary fields
+// to the upstream caller
 type rpcClientError struct {
-	Message   string
-	Instance  string
-	Expose    bool
-	Code      string
-	Namespace string
-	Type      string
+	Message   string `json:"message"`
+	Instance  string `json:"instance,omitempty"`
+	Expose    bool   `json:"expose,omitempty"`
+	Code      string `json:"code,omitempty"`
+	Namespace string `json:"namespace,omitempty"`
+	Type      string `json:"type,omitempty"`
 }
 
 func (e *rpcClientError) ErrorID() string {

--- a/lokerpc/server.go
+++ b/lokerpc/server.go
@@ -9,6 +9,7 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/LOKE/pkg/errors"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	jtd "github.com/jsontypedef/json-typedef-go"
@@ -431,9 +432,7 @@ func makeHandler(logger log.Logger, ec EndpointCodec) http.HandlerFunc {
 			logErr("err", e.Failed())
 
 			status = http.StatusBadRequest
-			result = struct {
-				Message string `json:"message"`
-			}{e.Failed().Error()}
+			result = formatErrResult(e.Failed())
 		} else {
 			if r, ok := result.(Resulter); ok {
 				result = r.Result()
@@ -457,4 +456,34 @@ func makeHandler(logger log.Logger, ec EndpointCodec) http.HandlerFunc {
 
 func writeBadReq(w http.ResponseWriter, format string, a ...interface{}) {
 	http.Error(w, fmt.Sprintf(format+"\n", a...), http.StatusBadRequest)
+}
+
+func formatErrResult(err error) any {
+	// If the error is an upstream error, just return it as-is
+	//
+	// Note we are intentionally not using errors.Is, we want to return the
+	// outer most error
+	if rpcErr, ok := err.(*rpcClientError); ok {
+		return rpcErr
+	}
+
+	// TODO: Support custom error attributes. If the error implements
+	// `MarshalJSON` we may want to call that, Ideally we would have a
+	// `ErrorAttributes() map[string]any`, but go's JSON encoding makes it hard
+	// to flatten them onto struct fields
+
+	// This is the minimum viable error result for LOKE rpc clients
+	errResult := struct {
+		Message string `json:"message"`
+		Expose  bool   `json:"expose,omitempty"`
+		Code    string `json:"code,omitempty"`
+		Type    string `json:"type,omitempty"`
+	}{
+		err.Error(),
+		errors.IsPublic(err),
+		errors.ErrorCode(err),
+		errors.ErrorType(err),
+	}
+
+	return errResult
 }

--- a/lokerpc/server_test.go
+++ b/lokerpc/server_test.go
@@ -53,7 +53,7 @@ func TestMountHandlers(t *testing.T) {
 			wantStatus: 400,
 		},
 		{
-			name: "upstream rpc error",
+			name: "upstream rpc error, expose true",
 			req:  httptest.NewRequest("POST", "/rpc/service1/basic", strings.NewReader(`{}`)),
 			endpointCoded: MakeStandardEndpointCodec(func(ctx context.Context, req struct{}) (*struct{}, error) {
 				return nil, &rpcClientError{
@@ -66,6 +66,22 @@ func TestMountHandlers(t *testing.T) {
 				}
 			}, ""),
 			wantBody:   `{"message":"some error","instance":"123","expose":true,"code":"bar","namespace":"foo","type":"https://example.com/errors/foo/bar"}`,
+			wantStatus: 400,
+		},
+		{
+			name: "upstream rpc error, expose false",
+			req:  httptest.NewRequest("POST", "/rpc/service1/basic", strings.NewReader(`{}`)),
+			endpointCoded: MakeStandardEndpointCodec(func(ctx context.Context, req struct{}) (*struct{}, error) {
+				return nil, &rpcClientError{
+					Message:   "some error",
+					Instance:  "123",
+					Expose:    false,
+					Code:      "bar",
+					Type:      "https://example.com/errors/foo/bar",
+					Namespace: "foo",
+				}
+			}, ""),
+			wantBody:   `{"message":"some error","instance":"123","code":"bar","namespace":"foo","type":"https://example.com/errors/foo/bar"}`,
 			wantStatus: 400,
 		},
 	}

--- a/lokerpc/server_test.go
+++ b/lokerpc/server_test.go
@@ -1,0 +1,97 @@
+package lokerpc
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/LOKE/pkg/errors"
+	"github.com/go-kit/log"
+)
+
+func TestMountHandlers(t *testing.T) {
+	// A basic type for requests and responses
+	type Foo struct {
+		Foo string `json:"foo"`
+	}
+
+	tests := []struct {
+		name          string
+		req           *http.Request
+		endpointCoded EndpointCodec
+		wantBody      string
+		wantStatus    int
+	}{
+		{
+			name: "basic request",
+			req:  httptest.NewRequest("POST", "/rpc/service1/basic", strings.NewReader(`{"foo":"bar"}`)),
+			endpointCoded: MakeStandardEndpointCodec(func(ctx context.Context, req Foo) (Foo, error) {
+				return Foo{"baz"}, nil
+			}, ""),
+			wantBody:   `{"foo":"baz"}`,
+			wantStatus: 200,
+		},
+		{
+			name: "public error",
+			req:  httptest.NewRequest("POST", "/rpc/service1/basic", strings.NewReader(`{}`)),
+			endpointCoded: MakeStandardEndpointCodec(func(ctx context.Context, req struct{}) (*struct{}, error) {
+				return nil, errors.NewPublicError("public_error_code", "Some public error")
+			}, ""),
+			wantBody:   `{"message":"Some public error","expose":true,"code":"public_error_code","type":"public_error_code"}`,
+			wantStatus: 400,
+		},
+		{
+			name: "generic error",
+			req:  httptest.NewRequest("POST", "/rpc/service1/basic", strings.NewReader(`{}`)),
+			endpointCoded: MakeStandardEndpointCodec(func(ctx context.Context, req struct{}) (*struct{}, error) {
+				return nil, fmt.Errorf("some error")
+			}, ""),
+			wantBody:   `{"message":"some error"}`,
+			wantStatus: 400,
+		},
+		{
+			name: "upstream rpc error",
+			req:  httptest.NewRequest("POST", "/rpc/service1/basic", strings.NewReader(`{}`)),
+			endpointCoded: MakeStandardEndpointCodec(func(ctx context.Context, req struct{}) (*struct{}, error) {
+				return nil, &rpcClientError{
+					Message:   "some error",
+					Instance:  "123",
+					Expose:    true,
+					Code:      "bar",
+					Type:      "https://example.com/errors/foo/bar",
+					Namespace: "foo",
+				}
+			}, ""),
+			wantBody:   `{"message":"some error","instance":"123","expose":true,"code":"bar","namespace":"foo","type":"https://example.com/errors/foo/bar"}`,
+			wantStatus: 400,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mux := http.NewServeMux()
+			MountHandlers(
+				log.NewNopLogger(),
+				mux,
+				NewService("service1", "", EndpointCodecMap{
+					"basic": tt.endpointCoded,
+				}),
+			)
+
+			rr := httptest.NewRecorder()
+			mux.ServeHTTP(rr, tt.req)
+
+			if rr.Code != tt.wantStatus {
+				t.Errorf("want status %d, got %d", tt.wantStatus, rr.Code)
+			}
+
+			gotBody := strings.Trim(rr.Body.String(), "\n")
+			if gotBody != tt.wantBody {
+				t.Errorf("want body %q, got %q", tt.wantBody, gotBody)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Alternative to #22

Adds support for public errors that can be exposed via RPC

Errors that implement the `Public() bool` method will be encoded `"expose": true` over rpc

Errors that implement the `ErrorCode() string` will be encoded `"code": "..."` over rpc.

Helper functions `NewPublicError` and `WrapWithPublicMessage` have been added to an errors package to make creating these public errors with codes easier to create

So when using the library you only have to include a single `errors` package, the most common std lib error functions have been re-exported