### PR TITLE
feat: implement ability to generate enums from go files

### DIFF
--- a/.custom-gcl.yml
+++ b/.custom-gcl.yml
@@ -1,0 +1,15 @@
+# Builds a custom golangci-lint binary bundling LOKE's "loke" module plugin.
+#
+#   go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
+#   golangci-lint custom            # produces ./bin/golangci-lint-loke
+#   ./bin/golangci-lint-loke run    # lints using .golangci.yml
+#
+# See lint/README.md.
+version: v2.12.2
+name: golangci-lint-loke
+destination: ./bin
+
+plugins:
+  - module: github.com/LOKE/pkg
+    import: github.com/LOKE/pkg/lint
+    path: .

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,12 @@
+version: "2"
+
+linters:
+  # Only LOKE's own checks run here; enable more linters as the team sees fit.
+  default: none
+  enable:
+    - loke
+  settings:
+    custom:
+      loke:
+        type: module
+        description: 'LOKE checks: enumtag enforces validate:"enum" on enum-typed struct fields'

--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,11 @@ go 1.26
 
 require (
 	github.com/go-kit/log v0.2.1
-	github.com/google/go-cmp v0.5.8
+	github.com/golangci/plugin-module-register v0.1.2
+	github.com/google/go-cmp v0.6.0
 	github.com/jsontypedef/json-typedef-go v0.0.0-20200503043955-4280071bd745
 	github.com/prometheus/client_golang v1.12.2
+	golang.org/x/tools v0.32.0
 )
 
 require (
@@ -18,7 +20,9 @@ require (
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.37.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect
-	golang.org/x/sys v0.0.0-20220731174439-a90be440212d // indirect
+	golang.org/x/mod v0.24.0 // indirect
+	golang.org/x/sync v0.13.0 // indirect
+	golang.org/x/sys v0.32.0 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -104,6 +104,8 @@ github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
+github.com/golangci/plugin-module-register v0.1.2 h1:e5WM6PO6NIAEcij3B053CohVp3HIYbzSuP53UAYgOpg=
+github.com/golangci/plugin-module-register v0.1.2/go.mod h1:1+QGTsKBvAIvPvoY/os+G5eoqxWn70HYDm2uvUyGuVw=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
@@ -115,8 +117,8 @@ github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
-github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
@@ -243,6 +245,8 @@ golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzB
 golang.org/x/mod v0.1.1-0.20191107180719-034126e5016b/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.24.0 h1:ZfthKaKaT4NrhGVZHO1/WDTwGES4De8KtWO0SIbNJMU=
+golang.org/x/mod v0.24.0/go.mod h1:IXM97Txy2VM4PJ3gI61r1YEk/gAj6zAHN3AdZt6S9Ww=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20181114220301-adae6a3d119a/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -290,6 +294,8 @@ golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.13.0 h1:AauUjRAJ9OSnvULf/ARrrVywoJDy0YS2AwQ98I37610=
+golang.org/x/sync v0.13.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -328,8 +334,8 @@ golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220731174439-a90be440212d h1:Sv5ogFZatcgIMMtBSTTAgMYsicp25MXBubjXNDKwm80=
-golang.org/x/sys v0.0.0-20220731174439-a90be440212d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.32.0 h1:s77OFDvIQeibCmezSnk/q6iAfkdiQaJi4VzroCFrN20=
+golang.org/x/sys v0.32.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -382,6 +388,8 @@ golang.org/x/tools v0.0.0-20200618134242-20370b0cb4b2/go.mod h1:EkVYQZoAsY45+roY
 golang.org/x/tools v0.0.0-20200729194436-6467de6f59a7/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200804011535-6c149bb5ef0d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200825202427-b303f430e36d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
+golang.org/x/tools v0.32.0 h1:Q7N1vhpkQv7ybVzLFtTjvQya2ewbwNDZzUgfXGqtMWU=
+golang.org/x/tools v0.32.0/go.mod h1:ZxrU41P/wAbZD8EDa6dDCa6XfpkhJ7HFMjHJXfBDu8s=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/lint/README.md
+++ b/lint/README.md
@@ -1,0 +1,32 @@
+# lint — LOKE's golangci-lint plugin
+
+`package lint` is a [golangci-lint module plugin](https://golangci-lint.run/docs/plugins/module-plugins/)
+registered under the name **`loke`**. It bundles LOKE-specific analyzers so every
+LOKE module can enforce the same checks from one custom golangci-lint build.
+
+## Analyzers
+
+| Analyzer  | Checks |
+|-----------|--------|
+| `enumtag` | Exported struct fields whose type implements `lokerpc.EnumProvider` (`EnumValues() []string`) must carry a `validate:"enum"` rule. This is the static replacement for the old runtime `lokerpc.AuditEnumValidatorTags`. |
+
+## Building and running
+
+The plugin must be compiled into a custom golangci-lint binary:
+
+```sh
+go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
+golangci-lint custom          # reads .custom-gcl.yml, writes ./bin/golangci-lint-loke
+./bin/golangci-lint-loke run  # reads .golangci.yml
+```
+
+The analyzer logic itself is exercised by ordinary `go test ./lint/...` (via
+`analysistest`), so it runs in normal CI without the custom binary.
+
+## Adding a check
+
+1. Add `myrule.go` to this package with `var MyRuleAnalyzer = &analysis.Analyzer{...}`.
+2. Append it to `Analyzers` in `loke.go`.
+3. Add `analysistest` fixtures under `testdata/src/...` and a test.
+
+Every module that enables the `loke` plugin then gets the new check for free.

--- a/lint/enumtag.go
+++ b/lint/enumtag.go
@@ -1,0 +1,135 @@
+package lint
+
+import (
+	"go/ast"
+	"go/types"
+	"reflect"
+	"strconv"
+	"strings"
+
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/inspect"
+	"golang.org/x/tools/go/ast/inspector"
+)
+
+const enumTagDoc = `check that enum-typed struct fields carry a validate:"enum" rule
+
+An enum is a named type that declares its permitted values through an
+EnumValues() []string method (lokerpc.EnumProvider). A struct field of such a
+type must be validated with the "enum" rule so the value is enforced at runtime.`
+
+// EnumTagAnalyzer reports exported struct fields whose type is an enum (a named
+// type implementing EnumValues() []string) but whose validate tag lacks the
+// "enum" rule. It is the static replacement for lokerpc.AuditEnumValidatorTags.
+var EnumTagAnalyzer = &analysis.Analyzer{
+	Name:     "enumtag",
+	Doc:      enumTagDoc,
+	URL:      "https://github.com/LOKE/pkg/tree/master/lint",
+	Requires: []*analysis.Analyzer{inspect.Analyzer},
+	Run:      runEnumTag,
+}
+
+func runEnumTag(pass *analysis.Pass) (any, error) {
+	insp := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+
+	insp.Preorder([]ast.Node{(*ast.StructType)(nil)}, func(n ast.Node) {
+		st := n.(*ast.StructType)
+		for _, field := range st.Fields.List {
+			// Embedded fields carry no name and can't hold a validate tag.
+			if len(field.Names) == 0 {
+				continue
+			}
+
+			enumName, ok := enumTypeName(pass.TypesInfo.TypeOf(field.Type))
+			if !ok || hasEnumRule(validateTag(field.Tag)) {
+				continue
+			}
+
+			for _, id := range field.Names {
+				if !id.IsExported() {
+					continue
+				}
+				pass.Reportf(id.Pos(),
+					"field %s is an enum type (%s) but its validate tag is missing the %q rule",
+					id.Name, enumName, "enum")
+			}
+		}
+	})
+
+	return nil, nil
+}
+
+// enumTypeName reports the name of t's underlying enum type and whether t is an
+// enum. Pointers and aliases are unwrapped, so *Currency and a CurrencyAlias are
+// both treated as Currency. A type is an enum when it is a named string type
+// whose value method set contains EnumValues() []string.
+func enumTypeName(t types.Type) (string, bool) {
+	if t == nil {
+		return "", false
+	}
+	t = types.Unalias(t)
+	if ptr, ok := t.(*types.Pointer); ok {
+		t = types.Unalias(ptr.Elem())
+	}
+	named, ok := t.(*types.Named)
+	if !ok {
+		return "", false
+	}
+	// Restrict to named string types: lokerpc only refs string types as enums,
+	// which also excludes interfaces and other types that happen to declare an
+	// EnumValues method.
+	if basic, ok := named.Underlying().(*types.Basic); !ok || basic.Info()&types.IsString == 0 {
+		return "", false
+	}
+	if !hasEnumValuesMethod(named) {
+		return "", false
+	}
+	return named.Obj().Name(), true
+}
+
+// hasEnumValuesMethod reports whether named's value method set contains a method
+// EnumValues() []string. Using the value method set (not the pointer's) mirrors
+// EnumProvider's value-receiver requirement.
+func hasEnumValuesMethod(named *types.Named) bool {
+	ms := types.NewMethodSet(named)
+	for i := 0; i < ms.Len(); i++ {
+		fn, ok := ms.At(i).Obj().(*types.Func)
+		if !ok || fn.Name() != "EnumValues" {
+			continue
+		}
+		sig, ok := fn.Type().(*types.Signature)
+		if !ok || sig.Params().Len() != 0 || sig.Results().Len() != 1 {
+			return false
+		}
+		slice, ok := sig.Results().At(0).Type().(*types.Slice)
+		if !ok {
+			return false
+		}
+		basic, ok := slice.Elem().(*types.Basic)
+		return ok && basic.Kind() == types.String
+	}
+	return false
+}
+
+// validateTag returns the value of the `validate` key in a struct field tag, or
+// "" when there is no tag or no validate key.
+func validateTag(tag *ast.BasicLit) string {
+	if tag == nil {
+		return ""
+	}
+	unquoted, err := strconv.Unquote(tag.Value)
+	if err != nil {
+		return ""
+	}
+	return reflect.StructTag(unquoted).Get("validate")
+}
+
+// hasEnumRule reports whether a validate tag value contains the "enum" rule.
+func hasEnumRule(validate string) bool {
+	for _, part := range strings.Split(validate, ",") {
+		if strings.TrimSpace(part) == "enum" {
+			return true
+		}
+	}
+	return false
+}

--- a/lint/enumtag_test.go
+++ b/lint/enumtag_test.go
@@ -1,0 +1,13 @@
+package lint_test
+
+import (
+	"testing"
+
+	"golang.org/x/tools/go/analysis/analysistest"
+
+	"github.com/LOKE/pkg/lint"
+)
+
+func TestEnumTagAnalyzer(t *testing.T) {
+	analysistest.Run(t, analysistest.TestData(), lint.EnumTagAnalyzer, "p")
+}

--- a/lint/loke.go
+++ b/lint/loke.go
@@ -1,0 +1,35 @@
+// Package lint provides LOKE's golangci-lint module plugin, registered under the
+// name "loke". It bundles LOKE-specific analyzers so every LOKE module can
+// enforce the same checks from a single custom golangci-lint build. Add new
+// checks by appending their analyzer to Analyzers.
+package lint
+
+import (
+	"github.com/golangci/plugin-module-register/register"
+	"golang.org/x/tools/go/analysis"
+)
+
+func init() {
+	register.Plugin("loke", New)
+}
+
+// Analyzers is the set of analyzers the "loke" plugin runs. Append new LOKE
+// checks here to enforce them across every module that enables the plugin.
+var Analyzers = []*analysis.Analyzer{
+	EnumTagAnalyzer,
+}
+
+// New constructs the loke plugin for golangci-lint. It takes no settings.
+func New(_ any) (register.LinterPlugin, error) {
+	return plugin{}, nil
+}
+
+type plugin struct{}
+
+func (plugin) BuildAnalyzers() ([]*analysis.Analyzer, error) {
+	return Analyzers, nil
+}
+
+func (plugin) GetLoadMode() string {
+	return register.LoadModeTypesInfo
+}

--- a/lint/testdata/src/p/p.go
+++ b/lint/testdata/src/p/p.go
@@ -1,0 +1,64 @@
+package p
+
+// Currency is an enum type: a named string with an EnumValues method
+// (i.e. it implements lokerpc.EnumProvider).
+type Currency string
+
+func (Currency) EnumValues() []string { return []string{"AUD", "NZD", "USD"} }
+
+// plainString is a named string with no EnumValues method, so it is not an enum.
+type plainString string
+
+type Good struct {
+	Currency Currency `json:"currency" validate:"enum"`
+}
+
+type GoodOptional struct {
+	Currency *Currency `json:"currency" validate:"omitempty,enum"`
+}
+
+type Untagged struct {
+	Currency Currency `json:"currency"` // want `field Currency is an enum type \(Currency\) but its validate tag is missing the "enum" rule`
+}
+
+type MissingEnumRule struct {
+	Currency *Currency `validate:"required"` // want `field Currency is an enum type \(Currency\) but its validate tag is missing the "enum" rule`
+}
+
+type NoTag struct {
+	Currency Currency // want `field Currency is an enum type \(Currency\) but its validate tag is missing the "enum" rule`
+}
+
+// NotEnumFields must not be flagged: neither field is an enum type.
+type NotEnumFields struct {
+	Name  string      `json:"name"`
+	Plain plainString `json:"plain"`
+}
+
+// unexportedEnum fields are skipped: they can't be validated by tag anyway.
+type unexportedEnum struct {
+	currency Currency `json:"currency"`
+}
+
+// CurrencyAlias is a type alias; enum detection must unwrap it (Go 1.23+).
+type CurrencyAlias = Currency
+
+type AliasField struct {
+	Currency CurrencyAlias `json:"currency"` // want `field Currency is an enum type \(Currency\) but its validate tag is missing the "enum" rule`
+}
+
+// enumLike is a named interface that declares EnumValues. It must NOT be treated
+// as an enum: only named string types are. A field of this type is not flagged.
+type enumLike interface {
+	EnumValues() []string
+}
+
+type InterfaceField struct {
+	Provider enumLike `json:"provider"`
+}
+
+// Embedded enum fields carry no field name, so the analyzer does not flag them
+// at the embedding site. This fixture documents that known limitation.
+type Embedded struct {
+	Currency
+}

--- a/lokerpc/README.md
+++ b/lokerpc/README.md
@@ -91,30 +91,33 @@ Schemas are generated automatically from Go types during `MountHandlers`. No man
 | named struct | definition + `{ref: "Name"}` |
 | `MarshalText()` | `{type: "string"}` |
 | `MarshalJSON()` | `{}` (any) |
-| named string with a registered `EnumSet` | enum definition + `{ref: "Name"}` |
+| named string implementing `EnumProvider` | enum definition + `{ref: "Name"}` |
 
 ### Enums
 
-Declare a named string type's values once with an `EnumSet`. `NewEnumSet` registers the type, so schema generation resolves its values by reflection — **the type needs no method of its own**. Each value is declared on a single line, and every field of that type (requests and responses alike) references the same enum definition with no per-field tag:
+Declare a named string type's values as `const`s and have the type implement `EnumProvider` (`EnumValues() []string`, **value receiver**). Schema generation resolves the values by reflection, and every field of that type (requests and responses alike) references the same enum definition with no per-field tag:
 
 ```go
 type Currency string
 
-var currencies = lokerpc.NewEnumSet[Currency]()
-
-var (
-    CurrencyAUD = currencies.Add("AUD")
-    CurrencyNZD = currencies.Add("NZD")
-    CurrencyUSD = currencies.Add("USD")
+const (
+    CurrencyAUD Currency = "AUD"
+    CurrencyNZD Currency = "NZD"
+    CurrencyUSD Currency = "USD"
 )
 
+// lokerpc.Enum keeps the returned values in sync with the declared consts.
+func (Currency) EnumValues() []string {
+    return lokerpc.Enum(CurrencyAUD, CurrencyNZD, CurrencyUSD)
+}
+
 type CreatePaymentRequest struct {
-    Currency Currency `json:"currency"`
+    Currency Currency `json:"currency" validate:"enum"`
     Amount   int32    `json:"amount" validate:"required,gt=0"`
 }
 ```
 
-The values are package `var`s rather than `const`s (a method call can't initialise a const); they're used identically in switches and map keys.
+Use a value receiver: schema generation relies on `reflect.Zero(t).Interface().(EnumProvider)`, which a pointer receiver fails silently.
 
 This produces:
 
@@ -130,9 +133,7 @@ This produces:
 }
 ```
 
-If you'd rather keep `const`s, the type can instead implement `EnumProvider` (`EnumValues() []string`, value receiver) and return `lokerpc.Enum(CurrencyAUD, CurrencyNZD, CurrencyUSD)` — schema generation falls back to that when no `EnumSet` is registered.
-
-To enforce the values on incoming requests, register a custom `enum` validator that looks the field's type up with `lokerpc.EnumValuesFor(field.Type())`, and tag the field with `validate:"enum"`. `lokerpc.AuditEnumValidatorTags(reflect.TypeOf(MyRequest{}))` can be used in a test to assert every enum field on a request type carries the rule.
+To enforce the values on incoming requests, register a custom `enum` validator that looks the field's type up with `lokerpc.EnumValuesFor(field.Type())`, and tag the field with `validate:"enum"`. The [`loke` golangci-lint plugin](../lint) (`enumtag` analyzer) statically checks that every enum-typed struct field carries that rule.
 
 ---
 
@@ -238,7 +239,7 @@ If you need to generate schemas outside of `MountHandlers`:
 ```go
 tdefs := map[reflect.Type]*lokerpc.NamedSchema{}
 
-// Build schema — EnumProvider types are detected and registered automatically
+// Build schema — EnumProvider types are detected automatically by reflection
 schema := lokerpc.TypeSchema(reflect.TypeOf(MyRequest{}), tdefs)
 
 // Resolve definitions

--- a/lokerpc/README.md
+++ b/lokerpc/README.md
@@ -1,0 +1,246 @@
+# lokerpc
+
+HTTP JSON-RPC framework for LOKE services. Endpoints are type-safe Go generics, schemas are generated from reflection, and TypeScript/Go clients are generated from the schema.
+
+## Wire format
+
+```
+POST /rpc/<service>/<method>   — invoke a method (JSON body in, JSON body out)
+GET  /rpc/<service>            — JTD schema for that service
+GET  /rpc                      — JTD schema for all mounted services
+```
+
+Errors are returned as HTTP 400 with a JSON body. 200 means success.
+
+---
+
+## Server
+
+### Defining a service
+
+```go
+svc, err := lokerpc.NewService("payments", "Payment processing", lokerpc.EndpointCodecMap{
+    "createPayment": lokerpc.MakeStandardEndpointCodec(
+        s.CreatePayment,
+        "Create a new payment",
+        lokerpc.NoNilResponse(),
+    ),
+    "cancelPayment": lokerpc.MakeVoidEndpointCodec(
+        s.CancelPayment,
+        "Cancel a payment",
+    ),
+})
+```
+
+- `MakeStandardEndpointCodec[Req, Res]` — for methods that return a value
+- `MakeVoidEndpointCodec[Req]` — for methods that only return an error
+- `NoNilResponse()` — returns a 500 if the handler returns a nil response without an error
+
+### Mounting
+
+```go
+lokerpc.MountHandlers(logger, mux, svc1, svc2, svc3)
+```
+
+This mounts all endpoints and the schema endpoints. Pass any `http.ServeMux` or compatible router.
+
+### Handler signature
+
+```go
+// Standard: returns a value
+func (s *Service) CreatePayment(ctx context.Context, req CreatePaymentRequest) (*Payment, error)
+
+// Void: no return value
+func (s *Service) CancelPayment(ctx context.Context, req CancelPaymentRequest) error
+```
+
+---
+
+## Client
+
+```go
+client := lokerpc.NewClient("http://payments-service/rpc/payments")
+
+var result Payment
+err := client.DoRequest(ctx, "createPayment", req, &result)
+
+// For void methods, pass nil as result
+err = client.DoRequest(ctx, "cancelPayment", req, nil)
+```
+
+Pass `X-Request-ID` and `X-Request-Deadline` headers are forwarded automatically from the context when present.
+
+---
+
+## Schema generation
+
+Schemas are generated automatically from Go types during `MountHandlers`. No manual schema writing required.
+
+### Type mapping
+
+| Go type | JTD schema |
+|---|---|
+| `string` | `{type: "string"}` |
+| `int`, `int32` | `{type: "int32"}` |
+| `float64` | `{type: "float64"}` |
+| `bool` | `{type: "boolean"}` |
+| `time.Time` | `{type: "timestamp"}` |
+| `*T` | `{...T, nullable: true}` |
+| `[]T` | `{elements: T, nullable: true}` |
+| `map[string]T` | `{values: T, nullable: true}` |
+| named struct | definition + `{ref: "Name"}` |
+| `MarshalText()` | `{type: "string"}` |
+| `MarshalJSON()` | `{}` (any) |
+| named string with a registered `EnumSet` | enum definition + `{ref: "Name"}` |
+
+### Enums
+
+Declare a named string type's values once with an `EnumSet`. `NewEnumSet` registers the type, so schema generation resolves its values by reflection — **the type needs no method of its own**. Each value is declared on a single line, and every field of that type (requests and responses alike) references the same enum definition with no per-field tag:
+
+```go
+type Currency string
+
+var currencies = lokerpc.NewEnumSet[Currency]()
+
+var (
+    CurrencyAUD = currencies.Add("AUD")
+    CurrencyNZD = currencies.Add("NZD")
+    CurrencyUSD = currencies.Add("USD")
+)
+
+type CreatePaymentRequest struct {
+    Currency Currency `json:"currency"`
+    Amount   int32    `json:"amount" validate:"required,gt=0"`
+}
+```
+
+The values are package `var`s rather than `const`s (a method call can't initialise a const); they're used identically in switches and map keys.
+
+This produces:
+
+```json
+{
+  "definitions": {
+    "Currency": { "enum": ["AUD", "NZD", "USD"] }
+  },
+  "properties": {
+    "currency": { "ref": "Currency" },
+    "amount":   { "type": "int32" }
+  }
+}
+```
+
+If you'd rather keep `const`s, the type can instead implement `EnumProvider` (`EnumValues() []string`, value receiver) and return `lokerpc.Enum(CurrencyAUD, CurrencyNZD, CurrencyUSD)` — schema generation falls back to that when no `EnumSet` is registered.
+
+To enforce the values on incoming requests, register a custom `enum` validator that looks the field's type up with `lokerpc.EnumValuesFor(field.Type())`, and tag the field with `validate:"enum"`. `lokerpc.AuditEnumValidatorTags(reflect.TypeOf(MyRequest{}))` can be used in a test to assert every enum field on a request type carries the rule.
+
+---
+
+## Code generation
+
+The `lokerpc/codegen` subpackage generates typed clients from a service's schema JSON.
+
+### TypeScript
+
+```go
+import "github.com/LOKE/pkg/lokerpc/codegen"
+
+var meta lokerpc.Meta
+// ... decode schema JSON into meta
+
+err := codegen.GenTypescriptClient(w, meta)
+```
+
+Output:
+
+```typescript
+export type Currency = "AUD" | "NZD" | "USD";
+
+export type CreatePaymentRequest = {
+  currency: Currency;
+  amount: number;
+};
+
+export class PaymentsService extends RPCContextClient {
+  createPayment(ctx: Context, req: CreatePaymentRequest): Promise<Payment> {
+    return this.request(ctx, "createPayment", req);
+  }
+}
+```
+
+### Go
+
+```go
+err := codegen.GenGoClient(w, meta)
+```
+
+Output:
+
+```go
+type Currency string
+
+const (
+    CurrencyAUD Currency = "AUD"
+    CurrencyNZD Currency = "NZD"
+    CurrencyUSD Currency = "USD"
+)
+
+type PaymentsService interface {
+    CreatePayment(context.Context, CreatePaymentRequest) (*Payment, error)
+}
+
+type PaymentsRPCClient struct{ lokerpc.Client }
+
+func (c PaymentsRPCClient) CreatePayment(ctx context.Context, req CreatePaymentRequest) (*Payment, error) {
+    var res Payment
+    err := c.DoRequest(ctx, "createPayment", req, &res)
+    if err != nil {
+        return nil, err
+    }
+    return &res, nil
+}
+```
+
+---
+
+## Error handling
+
+Return any `error` from a handler and it is serialised as a 400 response:
+
+```json
+{ "message": "something went wrong" }
+```
+
+Use `github.com/LOKE/pkg/errors` to expose structured errors to callers:
+
+```go
+// Public: exposes code, type, and message to the caller
+return nil, errors.NewPublicError("payment_declined", "Card was declined")
+
+// Private: only "message" is sent (no code/type)
+return nil, fmt.Errorf("db query failed: %w", err)
+```
+
+Public error response:
+
+```json
+{ "message": "Card was declined", "expose": true, "code": "payment_declined", "type": "payment_declined" }
+```
+
+Upstream RPC errors (received from another lokerpc client) are passed through to the caller as-is, preserving `instance`, `namespace`, and `type`.
+
+---
+
+## Advanced: low-level schema API
+
+If you need to generate schemas outside of `MountHandlers`:
+
+```go
+tdefs := map[reflect.Type]*lokerpc.NamedSchema{}
+
+// Build schema — EnumProvider types are detected and registered automatically
+schema := lokerpc.TypeSchema(reflect.TypeOf(MyRequest{}), tdefs)
+
+// Resolve definitions
+defs := lokerpc.TypeDefs(tdefs)
+```

--- a/lokerpc/codegen/go.go
+++ b/lokerpc/codegen/go.go
@@ -120,8 +120,25 @@ func GenGoClient(w io.Writer, meta lokerpc.Meta) error {
 	var b bytes.Buffer
 
 	for _, k := range defOrder {
+		def := meta.Definitions[k]
 		b.WriteString("\n")
-		fmt.Fprintf(&b, "type %s %s;\n", goFieldName(k), GenGoType(meta.Definitions[k], imports))
+		if def.Form() == jtd.FormEnum {
+			typeName := goFieldName(k)
+			fmt.Fprintf(&b, "type %s string\n", typeName)
+			if len(def.Enum) > 0 {
+				b.WriteString("\nconst (\n")
+				for _, v := range def.Enum {
+					suffix := goFieldName(v)
+					if suffix == "" {
+						continue
+					}
+					fmt.Fprintf(&b, "\t%s%s %s = %q\n", typeName, suffix, typeName, v)
+				}
+				b.WriteString(")\n")
+			}
+		} else {
+			fmt.Fprintf(&b, "type %s %s\n", goFieldName(k), GenGoType(def, imports))
+		}
 	}
 
 	// Service interface

--- a/lokerpc/codegen/testdata/enum.json
+++ b/lokerpc/codegen/testdata/enum.json
@@ -1,0 +1,28 @@
+{
+  "serviceName": "payment",
+  "help": "Payment service",
+  "multiArg": false,
+  "definitions": {
+    "Currency": {
+      "enum": ["AUD", "NZD", "USD", "GBP", "SGD"]
+    },
+    "PaymentState": {
+      "enum": ["created", "authorized", "submitted", "settled", "failed", "canceled", "refunded", "completed"]
+    }
+  },
+  "interfaces": [
+    {
+      "help": "Get payment state",
+      "methodName": "getState",
+      "methodTimeout": 30000,
+      "paramNames": [],
+      "requestTypeDef": {
+        "properties": {
+          "currency": {"ref": "Currency"},
+          "amount": {"type": "int32"}
+        }
+      },
+      "responseTypeDef": {"ref": "PaymentState"}
+    }
+  ]
+}

--- a/lokerpc/codegen/testdata/enum.json.go
+++ b/lokerpc/codegen/testdata/enum.json.go
@@ -1,0 +1,52 @@
+package payment
+
+import (
+	"context"
+
+	"github.com/LOKE/pkg/lokerpc"
+)
+
+type Currency string
+
+const (
+	CurrencyAUD Currency = "AUD"
+	CurrencyNZD Currency = "NZD"
+	CurrencyUSD Currency = "USD"
+	CurrencyGBP Currency = "GBP"
+	CurrencySGD Currency = "SGD"
+)
+
+type PaymentState string
+
+const (
+	PaymentStateCreated    PaymentState = "created"
+	PaymentStateAuthorized PaymentState = "authorized"
+	PaymentStateSubmitted  PaymentState = "submitted"
+	PaymentStateSettled    PaymentState = "settled"
+	PaymentStateFailed     PaymentState = "failed"
+	PaymentStateCanceled   PaymentState = "canceled"
+	PaymentStateRefunded   PaymentState = "refunded"
+	PaymentStateCompleted  PaymentState = "completed"
+)
+
+type GetStateRequest struct {
+	Amount   int32    `json:"amount"`
+	Currency Currency `json:"currency"`
+}
+
+type PaymentService interface {
+	GetState(context.Context, GetStateRequest) (*PaymentState, error)
+}
+
+type PaymentRPCClient struct {
+	lokerpc.Client
+}
+
+func (c PaymentRPCClient) GetState(ctx context.Context, req GetStateRequest) (*PaymentState, error) {
+	var res PaymentState
+	err := c.DoRequest(ctx, "getState", req, &res)
+	if err != nil {
+		return nil, err
+	}
+	return &res, nil
+}

--- a/lokerpc/codegen/testdata/enum.json.ts
+++ b/lokerpc/codegen/testdata/enum.json.ts
@@ -1,0 +1,26 @@
+import { RPCContextClient } from "@loke/http-rpc-client";
+import { Context } from "@loke/context";
+
+export type Currency = "AUD" | "NZD" | "USD" | "GBP" | "SGD";
+
+export type PaymentState = "created" | "authorized" | "submitted" | "settled" | "failed" | "canceled" | "refunded" | "completed";
+
+export type GetStateRequest = {
+  amount: number;
+  currency: Currency;
+};
+
+/**
+ * Payment service
+ */
+export class PaymentService extends RPCContextClient {
+  constructor(baseUrl: string) {
+    super(baseUrl, "payment")
+  }
+  /**
+   * Get payment state
+   */
+  getState(ctx: Context, req: GetStateRequest): Promise<PaymentState> {
+    return this.request(ctx, "getState", req);
+  }
+}

--- a/lokerpc/enum.go
+++ b/lokerpc/enum.go
@@ -4,60 +4,34 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
-	"sync"
 )
 
-// EnumSet declares the values of a string enum type T in one place and registers
-// them so schema generation and validation can resolve T's values by reflection
-// — the type itself needs no method. Declare one set per type at package scope,
-// then declare each value with Add; adding a value is a single line and nothing
-// ever drifts out of sync:
+// EnumProvider is implemented by a named string type to declare its permitted
+// values in one place, so schema generation and validation can resolve them by
+// reflection. Use a value receiver so reflect.Zero(t).Interface().(EnumProvider)
+// works during schema generation; a pointer receiver fails that assertion
+// silently.
 //
 //	type Currency string
 //
-//	var currencies = lokerpc.NewEnumSet[Currency]()
-//
-//	var (
-//	    CurrencyAUD = currencies.Add("AUD")
-//	    CurrencyNZD = currencies.Add("NZD")
-//	    CurrencyUSD = currencies.Add("USD")
+//	const (
+//	    CurrencyAUD Currency = "AUD"
+//	    CurrencyNZD Currency = "NZD"
+//	    CurrencyUSD Currency = "USD"
 //	)
 //
-// The values become package vars rather than consts (a method call can't
-// initialise a const), but are used identically in switches and map keys.
-type EnumSet[T ~string] struct {
-	mu     sync.RWMutex
-	values []string
+//	func (Currency) EnumValues() []string {
+//	    return lokerpc.Enum(CurrencyAUD, CurrencyNZD, CurrencyUSD)
+//	}
+type EnumProvider interface {
+	EnumValues() []string
 }
 
-// NewEnumSet creates an EnumSet for the string enum type T and registers it so
-// TypeSchema and EnumValuesFor can resolve T's values without T implementing any
-// interface. Call it once per type at package scope.
-func NewEnumSet[T ~string]() *EnumSet[T] {
-	s := &EnumSet[T]{}
-	registerEnum(reflect.TypeFor[T](), s.Values)
-	return s
-}
+// enumProviderType is the reflect.Type of EnumProvider.
+var enumProviderType = reflect.TypeOf((*EnumProvider)(nil)).Elem()
 
-// Add records v as a member of the set and returns it, so a named value and its
-// membership are declared in a single expression. Values are reported by Values
-// in the order they were added.
-func (s *EnumSet[T]) Add(v T) T {
-	s.mu.Lock()
-	s.values = append(s.values, string(v))
-	s.mu.Unlock()
-	return v
-}
-
-// Values returns the recorded values, in declaration order, as a fresh slice.
-func (s *EnumSet[T]) Values() []string {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	return append([]string(nil), s.values...)
-}
-
-// Enum converts typed string constants into a []string. Use it when you keep
-// your values as consts and prefer the EnumProvider interface over an EnumSet:
+// Enum converts typed string constants into a []string for an EnumValues
+// implementation, so a type's values and their declarations never drift apart:
 //
 //	func (Currency) EnumValues() []string {
 //	    return lokerpc.Enum(CurrencyAUD, CurrencyNZD, CurrencyUSD)
@@ -70,41 +44,16 @@ func Enum[T ~string](values ...T) []string {
 	return result
 }
 
-// EnumProvider is an optional alternative to NewEnumSet: a named string type can
-// declare its own values by implementing this interface. Use a value receiver so
-// reflect.Zero(t).Interface().(EnumProvider) works during schema generation; a
-// pointer receiver fails that assertion silently.
-type EnumProvider interface {
-	EnumValues() []string
-}
-
-// enumProviderType is the reflect.Type of EnumProvider.
-var enumProviderType = reflect.TypeOf((*EnumProvider)(nil)).Elem()
-
-// enumRegistry maps a registered enum type to an accessor for its current
-// values. It is written when an EnumSet is constructed (package init in normal
-// use) and read during schema generation and validation.
-var (
-	enumRegistryMu sync.RWMutex
-	enumRegistry   = map[reflect.Type]func() []string{}
-)
-
-func registerEnum(t reflect.Type, values func() []string) {
-	enumRegistryMu.Lock()
-	enumRegistry[t] = values
-	enumRegistryMu.Unlock()
-}
-
-// EnumValuesFor returns the enum values for a named string type, resolving them
-// from the EnumSet registry (preferred — no method required) or from an
-// EnumProvider implementation. ok is false if t is not a known enum. Custom
-// validators use this to enforce enum values at runtime.
+// EnumValuesFor returns the enum values for a named string type that implements
+// EnumProvider. A pointer to such a type is dereferenced first. ok is false if t
+// is not a known enum. Custom validators use this to enforce enum values at
+// runtime.
 func EnumValuesFor(t reflect.Type) (values []string, ok bool) {
-	enumRegistryMu.RLock()
-	fn, found := enumRegistry[t]
-	enumRegistryMu.RUnlock()
-	if found {
-		return fn(), true
+	// Deref pointers: *Currency's method set includes Currency's value-receiver
+	// EnumValues, but reflect.Zero(*Currency) is a nil pointer that would panic
+	// when EnumValues dereferences it.
+	for t.Kind() == reflect.Pointer {
+		t = t.Elem()
 	}
 	if t.Implements(enumProviderType) {
 		return reflect.Zero(t).Interface().(EnumProvider).EnumValues(), true
@@ -112,13 +61,10 @@ func EnumValuesFor(t reflect.Type) (values []string, ok bool) {
 	return nil, false
 }
 
-// isEnumType reports whether t is a known enum (registered or EnumProvider)
-// without materialising its values.
+// isEnumType reports whether t is a known enum (implements EnumProvider) without
+// materialising its values.
 func isEnumType(t reflect.Type) bool {
-	enumRegistryMu.RLock()
-	_, found := enumRegistry[t]
-	enumRegistryMu.RUnlock()
-	return found || t.Implements(enumProviderType)
+	return t.Implements(enumProviderType)
 }
 
 // AuditEnumValidatorTags walks t's exported fields recursively and returns one

--- a/lokerpc/enum.go
+++ b/lokerpc/enum.go
@@ -1,0 +1,175 @@
+package lokerpc
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"sync"
+)
+
+// EnumSet declares the values of a string enum type T in one place and registers
+// them so schema generation and validation can resolve T's values by reflection
+// — the type itself needs no method. Declare one set per type at package scope,
+// then declare each value with Add; adding a value is a single line and nothing
+// ever drifts out of sync:
+//
+//	type Currency string
+//
+//	var currencies = lokerpc.NewEnumSet[Currency]()
+//
+//	var (
+//	    CurrencyAUD = currencies.Add("AUD")
+//	    CurrencyNZD = currencies.Add("NZD")
+//	    CurrencyUSD = currencies.Add("USD")
+//	)
+//
+// The values become package vars rather than consts (a method call can't
+// initialise a const), but are used identically in switches and map keys.
+type EnumSet[T ~string] struct {
+	mu     sync.RWMutex
+	values []string
+}
+
+// NewEnumSet creates an EnumSet for the string enum type T and registers it so
+// TypeSchema and EnumValuesFor can resolve T's values without T implementing any
+// interface. Call it once per type at package scope.
+func NewEnumSet[T ~string]() *EnumSet[T] {
+	s := &EnumSet[T]{}
+	registerEnum(reflect.TypeFor[T](), s.Values)
+	return s
+}
+
+// Add records v as a member of the set and returns it, so a named value and its
+// membership are declared in a single expression. Values are reported by Values
+// in the order they were added.
+func (s *EnumSet[T]) Add(v T) T {
+	s.mu.Lock()
+	s.values = append(s.values, string(v))
+	s.mu.Unlock()
+	return v
+}
+
+// Values returns the recorded values, in declaration order, as a fresh slice.
+func (s *EnumSet[T]) Values() []string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return append([]string(nil), s.values...)
+}
+
+// Enum converts typed string constants into a []string. Use it when you keep
+// your values as consts and prefer the EnumProvider interface over an EnumSet:
+//
+//	func (Currency) EnumValues() []string {
+//	    return lokerpc.Enum(CurrencyAUD, CurrencyNZD, CurrencyUSD)
+//	}
+func Enum[T ~string](values ...T) []string {
+	result := make([]string, len(values))
+	for i, v := range values {
+		result[i] = string(v)
+	}
+	return result
+}
+
+// EnumProvider is an optional alternative to NewEnumSet: a named string type can
+// declare its own values by implementing this interface. Use a value receiver so
+// reflect.Zero(t).Interface().(EnumProvider) works during schema generation; a
+// pointer receiver fails that assertion silently.
+type EnumProvider interface {
+	EnumValues() []string
+}
+
+// enumProviderType is the reflect.Type of EnumProvider.
+var enumProviderType = reflect.TypeOf((*EnumProvider)(nil)).Elem()
+
+// enumRegistry maps a registered enum type to an accessor for its current
+// values. It is written when an EnumSet is constructed (package init in normal
+// use) and read during schema generation and validation.
+var (
+	enumRegistryMu sync.RWMutex
+	enumRegistry   = map[reflect.Type]func() []string{}
+)
+
+func registerEnum(t reflect.Type, values func() []string) {
+	enumRegistryMu.Lock()
+	enumRegistry[t] = values
+	enumRegistryMu.Unlock()
+}
+
+// EnumValuesFor returns the enum values for a named string type, resolving them
+// from the EnumSet registry (preferred — no method required) or from an
+// EnumProvider implementation. ok is false if t is not a known enum. Custom
+// validators use this to enforce enum values at runtime.
+func EnumValuesFor(t reflect.Type) (values []string, ok bool) {
+	enumRegistryMu.RLock()
+	fn, found := enumRegistry[t]
+	enumRegistryMu.RUnlock()
+	if found {
+		return fn(), true
+	}
+	if t.Implements(enumProviderType) {
+		return reflect.Zero(t).Interface().(EnumProvider).EnumValues(), true
+	}
+	return nil, false
+}
+
+// isEnumType reports whether t is a known enum (registered or EnumProvider)
+// without materialising its values.
+func isEnumType(t reflect.Type) bool {
+	enumRegistryMu.RLock()
+	_, found := enumRegistry[t]
+	enumRegistryMu.RUnlock()
+	return found || t.Implements(enumProviderType)
+}
+
+// AuditEnumValidatorTags walks t's exported fields recursively and returns one
+// error per field whose type (after dereferencing pointers) is a known enum but
+// whose validate tag is missing the "enum" rule. Call it from a test over your
+// request types to guarantee enum fields are validated at runtime.
+func AuditEnumValidatorTags(t reflect.Type) []error {
+	return auditEnumTagsInto(t, map[reflect.Type]bool{})
+}
+
+func auditEnumTagsInto(t reflect.Type, visited map[reflect.Type]bool) []error {
+	for t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+	if visited[t] {
+		return nil
+	}
+	visited[t] = true
+	if t.Kind() != reflect.Struct {
+		return nil
+	}
+
+	var errs []error
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+		if !f.IsExported() {
+			continue
+		}
+
+		ft := f.Type
+		for ft.Kind() == reflect.Pointer {
+			ft = ft.Elem()
+		}
+
+		if isEnumType(ft) && !hasEnumRule(f.Tag.Get("validate")) {
+			errs = append(errs, fmt.Errorf(
+				"%s.%s: %s is an enum type but validate tag lacks \"enum\" (got %q)",
+				t.Name(), f.Name, ft.Name(), f.Tag.Get("validate"),
+			))
+		}
+
+		errs = append(errs, auditEnumTagsInto(ft, visited)...)
+	}
+	return errs
+}
+
+func hasEnumRule(validateTag string) bool {
+	for _, part := range strings.Split(validateTag, ",") {
+		if strings.TrimSpace(part) == "enum" {
+			return true
+		}
+	}
+	return false
+}

--- a/lokerpc/enum.go
+++ b/lokerpc/enum.go
@@ -1,10 +1,6 @@
 package lokerpc
 
-import (
-	"fmt"
-	"reflect"
-	"strings"
-)
+import "reflect"
 
 // EnumProvider is implemented by a named string type to declare its permitted
 // values in one place, so schema generation and validation can resolve them by
@@ -23,6 +19,9 @@ import (
 //	func (Currency) EnumValues() []string {
 //	    return lokerpc.Enum(CurrencyAUD, CurrencyNZD, CurrencyUSD)
 //	}
+//
+// The enumtag analyzer (github.com/LOKE/pkg/lint) statically checks that struct
+// fields of an EnumProvider type carry a validate:"enum" rule.
 type EnumProvider interface {
 	EnumValues() []string
 }
@@ -59,63 +58,4 @@ func EnumValuesFor(t reflect.Type) (values []string, ok bool) {
 		return reflect.Zero(t).Interface().(EnumProvider).EnumValues(), true
 	}
 	return nil, false
-}
-
-// isEnumType reports whether t is a known enum (implements EnumProvider) without
-// materialising its values.
-func isEnumType(t reflect.Type) bool {
-	return t.Implements(enumProviderType)
-}
-
-// AuditEnumValidatorTags walks t's exported fields recursively and returns one
-// error per field whose type (after dereferencing pointers) is a known enum but
-// whose validate tag is missing the "enum" rule. Call it from a test over your
-// request types to guarantee enum fields are validated at runtime.
-func AuditEnumValidatorTags(t reflect.Type) []error {
-	return auditEnumTagsInto(t, map[reflect.Type]bool{})
-}
-
-func auditEnumTagsInto(t reflect.Type, visited map[reflect.Type]bool) []error {
-	for t.Kind() == reflect.Pointer {
-		t = t.Elem()
-	}
-	if visited[t] {
-		return nil
-	}
-	visited[t] = true
-	if t.Kind() != reflect.Struct {
-		return nil
-	}
-
-	var errs []error
-	for i := 0; i < t.NumField(); i++ {
-		f := t.Field(i)
-		if !f.IsExported() {
-			continue
-		}
-
-		ft := f.Type
-		for ft.Kind() == reflect.Pointer {
-			ft = ft.Elem()
-		}
-
-		if isEnumType(ft) && !hasEnumRule(f.Tag.Get("validate")) {
-			errs = append(errs, fmt.Errorf(
-				"%s.%s: %s is an enum type but validate tag lacks \"enum\" (got %q)",
-				t.Name(), f.Name, ft.Name(), f.Tag.Get("validate"),
-			))
-		}
-
-		errs = append(errs, auditEnumTagsInto(ft, visited)...)
-	}
-	return errs
-}
-
-func hasEnumRule(validateTag string) bool {
-	for _, part := range strings.Split(validateTag, ",") {
-		if strings.TrimSpace(part) == "enum" {
-			return true
-		}
-	}
-	return false
 }

--- a/lokerpc/schema.go
+++ b/lokerpc/schema.go
@@ -93,6 +93,19 @@ func TypeSchema(t reflect.Type, tdefs map[reflect.Type]*NamedSchema) *jtd.Schema
 		schema.Values = vals
 		schema.Nullable = true
 	case reflect.String:
+		if t.Name() != "" {
+			if values, ok := EnumValuesFor(t); ok {
+				if _, exists := tdefs[t]; !exists {
+					name := t.Name()
+					tdefs[t] = &NamedSchema{
+						Name:    name,
+						SortKey: fmt.Sprintf("%s.%s", t.PkgPath(), name),
+						Schema:  jtd.Schema{Enum: values},
+					}
+				}
+				return &jtd.Schema{Ref: &tdefs[t].Name}
+			}
+		}
 		schema.Type = jtd.TypeString
 	case reflect.Int:
 		schema.Type = jtd.TypeInt32

--- a/lokerpc/schema_test.go
+++ b/lokerpc/schema_test.go
@@ -64,29 +64,6 @@ func TestEnumProviderIsValueReceiver(t *testing.T) {
 	}
 }
 
-func TestAuditEnumValidatorTags(t *testing.T) {
-	type good struct {
-		Currency testCurrency `json:"currency" validate:"enum"`
-	}
-	if errs := AuditEnumValidatorTags(reflect.TypeOf(good{})); len(errs) != 0 {
-		t.Errorf("tagged enum field should pass audit, got %v", errs)
-	}
-
-	type goodOptional struct {
-		Currency *testCurrency `json:"currency" validate:"omitempty,enum"`
-	}
-	if errs := AuditEnumValidatorTags(reflect.TypeOf(goodOptional{})); len(errs) != 0 {
-		t.Errorf("omitempty,enum field should pass audit, got %v", errs)
-	}
-
-	type bad struct {
-		Currency testCurrency `json:"currency"`
-	}
-	if errs := AuditEnumValidatorTags(reflect.TypeOf(bad{})); len(errs) != 1 {
-		t.Errorf("untagged enum field should yield 1 audit error, got %v", errs)
-	}
-}
-
 type jsonMarshaler struct{}
 
 func (jsonMarshaler) MarshalJSON() ([]byte, error) {

--- a/lokerpc/schema_test.go
+++ b/lokerpc/schema_test.go
@@ -10,6 +10,140 @@ import (
 	jtd "github.com/jsontypedef/json-typedef-go"
 )
 
+type testCurrency string
+
+var testCurrencies = NewEnumSet[testCurrency]()
+
+var (
+	testCurrencyAUD = testCurrencies.Add("AUD")
+	testCurrencyGBP = testCurrencies.Add("GBP")
+	testCurrencyNZD = testCurrencies.Add("NZD")
+)
+
+func (testCurrency) EnumValues() []string { return testCurrencies.Values() }
+
+// regColor is registered via NewEnumSet and has NO EnumValues method — it
+// exercises the registry-only detection path.
+type regColor string
+
+var regColors = NewEnumSet[regColor]()
+
+var (
+	regColorRed  = regColors.Add("red")
+	regColorBlue = regColors.Add("blue")
+)
+
+// ifaceShade uses the EnumProvider interface only (no NewEnumSet) — it exercises
+// the interface fallback path.
+type ifaceShade string
+
+const (
+	ifaceShadeLight ifaceShade = "light"
+	ifaceShadeDark  ifaceShade = "dark"
+)
+
+func (ifaceShade) EnumValues() []string { return Enum(ifaceShadeLight, ifaceShadeDark) }
+
+func TestEnumHelper(t *testing.T) {
+	got := Enum(testCurrencyAUD, testCurrencyGBP, testCurrencyNZD)
+	want := []string{"AUD", "GBP", "NZD"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Enum() = %v, want %v", got, want)
+	}
+}
+
+func TestEnumSet(t *testing.T) {
+	type color string
+	set := NewEnumSet[color]()
+	red := set.Add("red")
+	blue := set.Add("blue")
+
+	if red != "red" || blue != "blue" {
+		t.Fatalf("Add should return the value it recorded: red=%q blue=%q", red, blue)
+	}
+
+	want := []string{"red", "blue"}
+	if got := set.Values(); !reflect.DeepEqual(got, want) {
+		t.Errorf("Values() = %v, want %v", got, want)
+	}
+
+	// Values must return a fresh slice so callers can't corrupt the set.
+	got := set.Values()
+	got[0] = "mutated"
+	if set.Values()[0] != "red" {
+		t.Error("Values() should return a defensive copy")
+	}
+}
+
+func TestEnumSetRegistersWithoutMethod(t *testing.T) {
+	// Add returns the typed value, so the declared names are usable constants.
+	if regColorRed != "red" || regColorBlue != "blue" {
+		t.Fatalf("Add should return the typed value: red=%q blue=%q", regColorRed, regColorBlue)
+	}
+
+	// regColor has no EnumValues method; schema generation must still detect it
+	// via the registry that NewEnumSet populated.
+	tdefs := map[reflect.Type]*NamedSchema{}
+	got := TypeSchema(reflect.TypeOf(struct {
+		Color regColor `json:"color"`
+	}{}), tdefs)
+
+	ref := got.Properties["color"].Ref
+	if ref == nil || *ref != "regColor" {
+		t.Fatalf("expected color to ref the regColor enum, got %+v", got.Properties["color"])
+	}
+	if defs := TypeDefs(tdefs); !reflect.DeepEqual(defs["regColor"].Enum, []string{"red", "blue"}) {
+		t.Errorf("regColor enum = %v, want [red blue]", defs["regColor"].Enum)
+	}
+}
+
+func TestEnumValuesFor(t *testing.T) {
+	// Registry-backed type (declared via NewEnumSet, no method).
+	if vals, ok := EnumValuesFor(reflect.TypeFor[regColor]()); !ok || !reflect.DeepEqual(vals, []string{"red", "blue"}) {
+		t.Errorf("EnumValuesFor(regColor) = %v, %v; want [red blue], true", vals, ok)
+	}
+	// Interface-backed type (EnumProvider, no NewEnumSet).
+	if vals, ok := EnumValuesFor(reflect.TypeFor[ifaceShade]()); !ok || !reflect.DeepEqual(vals, []string{"light", "dark"}) {
+		t.Errorf("EnumValuesFor(ifaceShade) = %v, %v; want [light dark], true", vals, ok)
+	}
+	// A plain string is not a known enum.
+	if _, ok := EnumValuesFor(reflect.TypeFor[string]()); ok {
+		t.Error("plain string should not be a known enum")
+	}
+}
+
+func TestEnumProviderIsValueReceiver(t *testing.T) {
+	// EnumProvider must be satisfied by the value (not the pointer): schema
+	// generation relies on reflect.Zero(t).Interface().(EnumProvider).
+	var _ EnumProvider = testCurrency("")
+	if _, ok := reflect.Zero(reflect.TypeOf(testCurrency(""))).Interface().(EnumProvider); !ok {
+		t.Fatal("testCurrency value does not satisfy EnumProvider (pointer receiver?)")
+	}
+}
+
+func TestAuditEnumValidatorTags(t *testing.T) {
+	type good struct {
+		Currency testCurrency `json:"currency" validate:"enum"`
+	}
+	if errs := AuditEnumValidatorTags(reflect.TypeOf(good{})); len(errs) != 0 {
+		t.Errorf("tagged enum field should pass audit, got %v", errs)
+	}
+
+	type goodOptional struct {
+		Currency *testCurrency `json:"currency" validate:"omitempty,enum"`
+	}
+	if errs := AuditEnumValidatorTags(reflect.TypeOf(goodOptional{})); len(errs) != 0 {
+		t.Errorf("omitempty,enum field should pass audit, got %v", errs)
+	}
+
+	type bad struct {
+		Currency testCurrency `json:"currency"`
+	}
+	if errs := AuditEnumValidatorTags(reflect.TypeOf(bad{})); len(errs) != 1 {
+		t.Errorf("untagged enum field should yield 1 audit error, got %v", errs)
+	}
+}
+
 type jsonMarshaler struct{}
 
 func (jsonMarshaler) MarshalJSON() ([]byte, error) {
@@ -232,6 +366,38 @@ func TestTypeSchema(t *testing.T) {
 				t: reflect.TypeOf(&textMarshaler{}),
 			},
 			want: `{"type":"string","nullable": true}`,
+		},
+		{
+			name: "named string implementing EnumProvider becomes enum ref",
+			args: args{
+				t: reflect.TypeOf(struct {
+					Currency testCurrency `json:"currency"`
+				}{}),
+			},
+			want: `{
+				"definitions": {
+					"testCurrency": {"enum": ["AUD", "GBP", "NZD"]}
+				},
+				"properties": {
+					"currency": {"ref": "testCurrency"}
+				}
+			}`,
+		},
+		{
+			name: "pointer to EnumProvider type is nullable ref",
+			args: args{
+				t: reflect.TypeOf(struct {
+					Currency *testCurrency `json:"currency"`
+				}{}),
+			},
+			want: `{
+				"definitions": {
+					"testCurrency": {"enum": ["AUD", "GBP", "NZD"]}
+				},
+				"properties": {
+					"currency": {"ref": "testCurrency", "nullable": true}
+				}
+			}`,
 		},
 		{
 			name: "recusive type",

--- a/lokerpc/schema_test.go
+++ b/lokerpc/schema_test.go
@@ -12,29 +12,17 @@ import (
 
 type testCurrency string
 
-var testCurrencies = NewEnumSet[testCurrency]()
-
-var (
-	testCurrencyAUD = testCurrencies.Add("AUD")
-	testCurrencyGBP = testCurrencies.Add("GBP")
-	testCurrencyNZD = testCurrencies.Add("NZD")
+const (
+	testCurrencyAUD testCurrency = "AUD"
+	testCurrencyGBP testCurrency = "GBP"
+	testCurrencyNZD testCurrency = "NZD"
 )
 
-func (testCurrency) EnumValues() []string { return testCurrencies.Values() }
+func (testCurrency) EnumValues() []string {
+	return Enum(testCurrencyAUD, testCurrencyGBP, testCurrencyNZD)
+}
 
-// regColor is registered via NewEnumSet and has NO EnumValues method — it
-// exercises the registry-only detection path.
-type regColor string
-
-var regColors = NewEnumSet[regColor]()
-
-var (
-	regColorRed  = regColors.Add("red")
-	regColorBlue = regColors.Add("blue")
-)
-
-// ifaceShade uses the EnumProvider interface only (no NewEnumSet) — it exercises
-// the interface fallback path.
+// ifaceShade is a second EnumProvider type, declared with consts.
 type ifaceShade string
 
 const (
@@ -52,59 +40,14 @@ func TestEnumHelper(t *testing.T) {
 	}
 }
 
-func TestEnumSet(t *testing.T) {
-	type color string
-	set := NewEnumSet[color]()
-	red := set.Add("red")
-	blue := set.Add("blue")
-
-	if red != "red" || blue != "blue" {
-		t.Fatalf("Add should return the value it recorded: red=%q blue=%q", red, blue)
-	}
-
-	want := []string{"red", "blue"}
-	if got := set.Values(); !reflect.DeepEqual(got, want) {
-		t.Errorf("Values() = %v, want %v", got, want)
-	}
-
-	// Values must return a fresh slice so callers can't corrupt the set.
-	got := set.Values()
-	got[0] = "mutated"
-	if set.Values()[0] != "red" {
-		t.Error("Values() should return a defensive copy")
-	}
-}
-
-func TestEnumSetRegistersWithoutMethod(t *testing.T) {
-	// Add returns the typed value, so the declared names are usable constants.
-	if regColorRed != "red" || regColorBlue != "blue" {
-		t.Fatalf("Add should return the typed value: red=%q blue=%q", regColorRed, regColorBlue)
-	}
-
-	// regColor has no EnumValues method; schema generation must still detect it
-	// via the registry that NewEnumSet populated.
-	tdefs := map[reflect.Type]*NamedSchema{}
-	got := TypeSchema(reflect.TypeOf(struct {
-		Color regColor `json:"color"`
-	}{}), tdefs)
-
-	ref := got.Properties["color"].Ref
-	if ref == nil || *ref != "regColor" {
-		t.Fatalf("expected color to ref the regColor enum, got %+v", got.Properties["color"])
-	}
-	if defs := TypeDefs(tdefs); !reflect.DeepEqual(defs["regColor"].Enum, []string{"red", "blue"}) {
-		t.Errorf("regColor enum = %v, want [red blue]", defs["regColor"].Enum)
-	}
-}
-
 func TestEnumValuesFor(t *testing.T) {
-	// Registry-backed type (declared via NewEnumSet, no method).
-	if vals, ok := EnumValuesFor(reflect.TypeFor[regColor]()); !ok || !reflect.DeepEqual(vals, []string{"red", "blue"}) {
-		t.Errorf("EnumValuesFor(regColor) = %v, %v; want [red blue], true", vals, ok)
-	}
-	// Interface-backed type (EnumProvider, no NewEnumSet).
+	// EnumProvider-backed type resolves to its declared values.
 	if vals, ok := EnumValuesFor(reflect.TypeFor[ifaceShade]()); !ok || !reflect.DeepEqual(vals, []string{"light", "dark"}) {
 		t.Errorf("EnumValuesFor(ifaceShade) = %v, %v; want [light dark], true", vals, ok)
+	}
+	// A pointer to an EnumProvider type resolves too (and must not panic).
+	if vals, ok := EnumValuesFor(reflect.TypeFor[*ifaceShade]()); !ok || !reflect.DeepEqual(vals, []string{"light", "dark"}) {
+		t.Errorf("EnumValuesFor(*ifaceShade) = %v, %v; want [light dark], true", vals, ok)
 	}
 	// A plain string is not a known enum.
 	if _, ok := EnumValuesFor(reflect.TypeFor[string]()); ok {


### PR DESCRIPTION
Internal change only

2 new features:

- Go-defined RPC services can now define enum types for typescript generation
- When generating go code, it can now generate based on the custom enums

<!--
## Related PRs
- https://github.com/LOKE/example/pull/1
-->

<!--
## Rollback Instructions

-->

## Screenshots / Videos

```go
type BillingType string

// Note these map to the database enum so if these are added to then a migration will be required
const (
	BillingTypePosCheckin    BillingType = "pos/checkin"
	BillingTypeAppItem       BillingType = "app/item"
	BillingTypeAppCredit     BillingType = "app/credit"
	BillingTypePosBill       BillingType = "pos/bill"
	BillingTypePosTerminal   BillingType = "pos/terminal"
	BillingTypeOrderPickup   BillingType = "order/pickup"
	BillingTypeOrderExternal BillingType = "order/external"
	BillingTypeOrderService  BillingType = "order/service"
	BillingTypeOrderDelivery BillingType = "order/delivery"
)

// EnumValues implements lokerpc.EnumProvider.
func (BillingType) EnumValues() []string {
	return lokerpc.Enum(
		BillingTypePosCheckin,
		BillingTypeAppItem,
		BillingTypeAppCredit,
		BillingTypePosBill,
		BillingTypePosTerminal,
		BillingTypeOrderPickup,
		BillingTypeOrderExternal,
		BillingTypeOrderService,
		BillingTypeOrderDelivery,
	)
}
```

<img width="273" height="272" alt="image" src="https://github.com/user-attachments/assets/8e6a28ee-d236-4b3b-97d0-35cbd2a96f81" />


##  I have:
- [x] Run and tested the code and provided clear evidence of this above
- [x] Self reviewed the code and removed extraneous comments, debug logging, checked code style
- [x] Listed any dependant PRs required for this change
- [x] Added tests where practical and possible
- [x] Documented a way to roll this change back if it is more than a code revert

_all the above **must** be ticked_
