### PR TITLE
Add rpc client metrics

### DIFF
--- a/lokerpc/client.go
+++ b/lokerpc/client.go
@@ -63,6 +63,10 @@ func (e *rpcClientError) ErrorType() string {
 	return e.Type
 }
 
+func (e *rpcClientError) ErrorCode() string {
+	return e.Code
+}
+
 func (e *rpcClientError) Public() bool {
 	return e.Expose
 }

--- a/lokerpc/client.go
+++ b/lokerpc/client.go
@@ -127,7 +127,7 @@ func (c Client) DoRequest(ctx context.Context, method string, args, result any) 
 		errType := "unknown"
 		if rpcErr, ok := errors.AsType[*rpcClientError](finalErr); ok {
 			errType = rpcErr.Type
-		} else if errors.Is(finalErr, &json.InvalidUnmarshalError{}) {
+		} else if _, ok := finalErr.(*json.InvalidUnmarshalError); ok {
 			errType = "json_decode_error"
 		} else if finalErr == context.Canceled {
 			errType = "aborted"

--- a/lokerpc/client.go
+++ b/lokerpc/client.go
@@ -129,6 +129,8 @@ func (c Client) DoRequest(ctx context.Context, method string, args, result any) 
 			errType = rpcErr.Type
 		} else if _, ok := finalErr.(*json.InvalidUnmarshalError); ok {
 			errType = "json_decode_error"
+		} else if _, ok := finalErr.(*json.SyntaxError); ok {
+			errType = "json_decode_error"
 		} else if finalErr == context.Canceled {
 			errType = "aborted"
 		}

--- a/lokerpc/client.go
+++ b/lokerpc/client.go
@@ -6,10 +6,34 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 
+	"github.com/LOKE/pkg/errors"
 	"github.com/LOKE/pkg/requestid"
+	"github.com/prometheus/client_golang/prometheus"
 )
+
+var clientLatency *prometheus.HistogramVec = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+	Name: "http_rpc_client_request_duration_seconds",
+	Help: "Duration of rpc requests from the client",
+}, []string{"service", "method"})
+
+var clientRequestCount *prometheus.CounterVec = prometheus.NewCounterVec(prometheus.CounterOpts{
+	Name: "http_rpc_client_requests_total",
+	Help: "The total number of rpc requests from the client",
+}, []string{"service", "method"})
+
+var clientFailures *prometheus.CounterVec = prometheus.NewCounterVec(prometheus.CounterOpts{
+	Name: "http_rpc_client_failures_total",
+	Help: "The total number of rpc failures received",
+}, []string{"service", "method", "type", "status_code"})
+
+func init() {
+	prometheus.MustRegister(clientLatency)
+	prometheus.MustRegister(clientRequestCount)
+	prometheus.MustRegister(clientFailures)
+}
 
 func NewClient(baseURL string) Client {
 	return newClientWithClient(baseURL, http.DefaultClient)
@@ -57,7 +81,7 @@ func normalizeBaseURL(baseURL string) string {
 	return strings.TrimRight(baseURL, "/") + "/"
 }
 
-func (c Client) DoRequest(ctx context.Context, method string, args, result any) error {
+func (c Client) DoRequest(ctx context.Context, method string, args, result any) (finalErr error) {
 	b := new(bytes.Buffer)
 	if err := json.NewEncoder(b).Encode(args); err != nil {
 		return err
@@ -68,6 +92,9 @@ func (c Client) DoRequest(ctx context.Context, method string, args, result any) 
 	if err != nil {
 		return err
 	}
+
+	defer prometheus.NewTimer(clientLatency.WithLabelValues(c.bURL, method)).ObserveDuration()
+	clientRequestCount.WithLabelValues(c.bURL, method).Inc()
 
 	req.Header.Set("Content-Type", "application/json")
 
@@ -87,6 +114,28 @@ func (c Client) DoRequest(ctx context.Context, method string, args, result any) 
 
 	req = req.WithContext(ctx)
 	res, err := c.client.Do(req)
+
+	defer func() {
+		if finalErr == nil {
+			return
+		}
+
+		errType := "unknown"
+		if rpcErr, ok := errors.AsType[*rpcClientError](err); ok {
+			errType = rpcErr.Type
+		} else if errors.Is(err, &json.InvalidUnmarshalError{}) {
+			errType = "json_decode_error"
+		} else if err == context.Canceled {
+			errType = "aborted"
+		}
+
+		status := "-1"
+		if res != nil {
+			status = strconv.Itoa(res.StatusCode)
+		}
+
+		clientFailures.WithLabelValues(c.bURL, method, errType, status).Inc()
+	}()
 
 	if err != nil {
 		return err

--- a/lokerpc/client.go
+++ b/lokerpc/client.go
@@ -125,11 +125,11 @@ func (c Client) DoRequest(ctx context.Context, method string, args, result any) 
 		}
 
 		errType := "unknown"
-		if rpcErr, ok := errors.AsType[*rpcClientError](err); ok {
+		if rpcErr, ok := errors.AsType[*rpcClientError](finalErr); ok {
 			errType = rpcErr.Type
-		} else if errors.Is(err, &json.InvalidUnmarshalError{}) {
+		} else if errors.Is(finalErr, &json.InvalidUnmarshalError{}) {
 			errType = "json_decode_error"
-		} else if err == context.Canceled {
+		} else if finalErr == context.Canceled {
 			errType = "aborted"
 		}
 

--- a/lokerpc/client_test.go
+++ b/lokerpc/client_test.go
@@ -1,8 +1,14 @@
 package lokerpc
 
 import (
+	"context"
+	"io"
 	"net/http"
+	"net/http/httptest"
+	"reflect"
 	"testing"
+
+	"github.com/LOKE/pkg/errors"
 )
 
 func TestNewClientNormalizesBaseURL(t *testing.T) {
@@ -31,13 +37,96 @@ func TestNewClientNormalizesBaseURL(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
 			c := newClientWithClient(tc.baseURL, http.DefaultClient)
+
 			if c.bURL != tc.expected {
 				t.Fatalf("expected normalized base URL %q, got %q", tc.expected, c.bURL)
+			}
+		})
+	}
+}
+
+func TestClient_DoRequest(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/notFound", http.NotFound)
+	mux.HandleFunc("/echo", func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(body)
+	})
+	mux.HandleFunc("/echo_error", func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(400)
+		w.Write(body)
+	})
+	mux.HandleFunc("/drop", func(w http.ResponseWriter, r *http.Request) {
+		conn, _, _ := http.NewResponseController(w).Hijack()
+		conn.Close()
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	tests := []struct {
+		name string // description of this test case
+		// Named input parameters for target function.
+		method      string
+		args        any
+		result      any
+		want        any
+		wantErr     bool
+		wantErrCode string
+	}{
+		{
+			name:   "basic echo",
+			method: "echo",
+			args:   struct{ Foo string }{Foo: "bar"},
+			result: &struct{ Foo string }{},
+			want:   &struct{ Foo string }{Foo: "bar"},
+		},
+		{
+			name:   "basic error",
+			method: "echo_error",
+			args: struct {
+				Code string `json:"code"`
+			}{Code: "foo_bar"},
+			wantErr:     true,
+			wantErrCode: "foo_bar",
+		},
+		{
+			name:    "drop",
+			method:  "drop",
+			wantErr: true,
+		},
+		{
+			name:    "not found",
+			method:  "notFound",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			c := NewClient(server.URL)
+			gotErr := c.DoRequest(context.Background(), tt.method, tt.args, tt.result)
+
+			if tt.wantErr == (gotErr == nil) {
+				t.Errorf("DoRequest() failed: got error %v, want %v", gotErr, tt.wantErr)
+			}
+
+			if tt.wantErrCode != "" {
+				if gotErr == nil || errors.ErrorCode(gotErr) != tt.wantErrCode {
+					t.Errorf("DoRequest() error code mismatch: got %v, want %v",
+						errors.ErrorCode(gotErr), tt.wantErrCode)
+				}
+			}
+
+			if tt.want != nil {
+				if !reflect.DeepEqual(tt.result, tt.want) {
+					t.Errorf("DoRequest() result mismatch: got %v, want %v", tt.result, tt.want)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
Added these to match the JS metrics

Using a named return type here is a little bit clever, but it prevents the need for incrementing the metric before every return. Could have wrapped the error handling in a func I guess, but this seems fine.

Added tests to confirm data passes through as expected