### PR TITLE
feat: support embedded structs appropriately in the RPC schemas

### DIFF
--- a/lokerpc/schema.go
+++ b/lokerpc/schema.go
@@ -20,6 +20,10 @@ type NamedSchema struct {
 // addStructFields writes t's fields into schema, promoting the fields of
 // untagged embedded structs the way encoding/json does.
 func addStructFields(t reflect.Type, schema *jtd.Schema, tdefs map[reflect.Type]*NamedSchema) {
+	addStructFieldsSeen(t, schema, tdefs, map[reflect.Type]bool{t: true})
+}
+
+func addStructFieldsSeen(t reflect.Type, schema *jtd.Schema, tdefs map[reflect.Type]*NamedSchema, seen map[reflect.Type]bool) {
 	for f := range t.Fields() {
 		if !f.IsExported() {
 			continue
@@ -32,7 +36,13 @@ func addStructFields(t reflect.Type, schema *jtd.Schema, tdefs map[reflect.Type]
 
 		if f.Anonymous && name == "" {
 			if ft := indirect(f.Type); ft.Kind() == reflect.Struct && ft != timeType {
-				addStructFields(ft, schema, tdefs)
+				// Recursive embedding (Node embeds *Node) can't be promoted;
+				// encoding/json drops the deeper copies too.
+				if !seen[ft] {
+					seen[ft] = true
+					addStructFieldsSeen(ft, schema, tdefs, seen)
+					delete(seen, ft)
+				}
 				continue
 			}
 		}

--- a/lokerpc/schema.go
+++ b/lokerpc/schema.go
@@ -24,6 +24,8 @@ func addStructFields(t reflect.Type, schema *jtd.Schema, tdefs map[reflect.Type]
 }
 
 func addStructFieldsSeen(t reflect.Type, schema *jtd.Schema, tdefs map[reflect.Type]*NamedSchema, seen map[reflect.Type]bool) {
+	var embedded []reflect.Type
+
 	for f := range t.Fields() {
 		if !f.IsExported() {
 			continue
@@ -36,13 +38,7 @@ func addStructFieldsSeen(t reflect.Type, schema *jtd.Schema, tdefs map[reflect.T
 
 		if f.Anonymous && name == "" {
 			if ft := indirect(f.Type); ft.Kind() == reflect.Struct && ft != timeType {
-				// Recursive embedding (Node embeds *Node) can't be promoted;
-				// encoding/json drops the deeper copies too.
-				if !seen[ft] {
-					seen[ft] = true
-					addStructFieldsSeen(ft, schema, tdefs, seen)
-					delete(seen, ft)
-				}
+				embedded = append(embedded, ft)
 				continue
 			}
 		}
@@ -62,6 +58,44 @@ func addStructFieldsSeen(t reflect.Type, schema *jtd.Schema, tdefs map[reflect.T
 			schema.Properties[name] = *s
 		}
 	}
+
+	// Promoted fields are merged last so an outer field always shadows an
+	// embedded one of the same name, whatever the declaration order.
+	for _, ft := range embedded {
+		// Recursive embedding (Node embeds *Node) can't be promoted;
+		// encoding/json drops the deeper copies too.
+		if seen[ft] {
+			continue
+		}
+		seen[ft] = true
+
+		sub := jtd.Schema{Properties: make(map[string]jtd.Schema)}
+		addStructFieldsSeen(ft, &sub, tdefs, seen)
+		delete(seen, ft)
+
+		for name, s := range sub.Properties {
+			if !hasProperty(schema, name) {
+				schema.Properties[name] = s
+			}
+		}
+		for name, s := range sub.OptionalProperties {
+			if hasProperty(schema, name) {
+				continue
+			}
+			if schema.OptionalProperties == nil {
+				schema.OptionalProperties = make(map[string]jtd.Schema)
+			}
+			schema.OptionalProperties[name] = s
+		}
+	}
+}
+
+func hasProperty(schema *jtd.Schema, name string) bool {
+	if _, ok := schema.Properties[name]; ok {
+		return true
+	}
+	_, ok := schema.OptionalProperties[name]
+	return ok
 }
 
 func indirect(t reflect.Type) reflect.Type {

--- a/lokerpc/schema.go
+++ b/lokerpc/schema.go
@@ -17,6 +17,50 @@ type NamedSchema struct {
 	Schema  jtd.Schema
 }
 
+// addStructFields writes t's fields into schema, promoting the fields of
+// untagged embedded structs the way encoding/json does.
+func addStructFields(t reflect.Type, schema *jtd.Schema, tdefs map[reflect.Type]*NamedSchema) {
+	for f := range t.Fields() {
+		if !f.IsExported() {
+			continue
+		}
+
+		name, omit := parseTag(f.Tag.Get("json"))
+		if name == "-" {
+			continue
+		}
+
+		if f.Anonymous && name == "" {
+			if ft := indirect(f.Type); ft.Kind() == reflect.Struct && ft != timeType {
+				addStructFields(ft, schema, tdefs)
+				continue
+			}
+		}
+
+		if name == "" {
+			name = f.Name
+		}
+		s := TypeSchema(f.Type, tdefs)
+		if omit {
+			if schema.OptionalProperties == nil {
+				schema.OptionalProperties = make(map[string]jtd.Schema)
+			}
+
+			s.Nullable = false // maybe shouldn't be necessary
+			schema.OptionalProperties[name] = *s
+		} else {
+			schema.Properties[name] = *s
+		}
+	}
+}
+
+func indirect(t reflect.Type) reflect.Type {
+	if t.Kind() == reflect.Pointer {
+		return t.Elem()
+	}
+	return t
+}
+
 func TypeSchema(t reflect.Type, tdefs map[reflect.Type]*NamedSchema) *jtd.Schema {
 	if ns, ok := tdefs[t]; ok {
 		return &jtd.Schema{Ref: &ns.Name}
@@ -52,29 +96,7 @@ func TypeSchema(t reflect.Type, tdefs map[reflect.Type]*NamedSchema) *jtd.Schema
 
 			schema.Properties = make(map[string]jtd.Schema)
 
-			for i := 0; i < t.NumField(); i++ {
-				f := t.Field(i)
-
-				if !f.IsExported() {
-					continue
-				}
-
-				name, omit := parseTag(f.Tag.Get("json"))
-				if name == "" {
-					name = f.Name
-				}
-				s := TypeSchema(f.Type, tdefs)
-				if omit {
-					if schema.OptionalProperties == nil {
-						schema.OptionalProperties = make(map[string]jtd.Schema)
-					}
-
-					s.Nullable = false // maybe shouldn't be necessary
-					schema.OptionalProperties[name] = *s
-				} else {
-					schema.Properties[name] = *s
-				}
-			}
+			addStructFields(t, &schema, tdefs)
 
 			if nt, ok := tdefs[t]; ok {
 				nt.Schema = schema

--- a/lokerpc/schema_test.go
+++ b/lokerpc/schema_test.go
@@ -133,6 +133,70 @@ func TestTypeSchema(t *testing.T) {
 			want: `{"properties": {}}`,
 		},
 		{
+			name: "embedded struct is promoted, not nested",
+			args: args{
+				t: reflect.TypeOf(struct {
+					NamedStruct
+					Bar string `json:"bar"`
+				}{}),
+			},
+			want: `{
+				"properties": {
+					"foo": { "type": "string" },
+					"bar": { "type": "string" }
+				}
+			}`,
+		},
+		{
+			name: "embedded pointer to struct is promoted",
+			args: args{
+				t: reflect.TypeOf(struct {
+					*NamedStruct
+					Bar string `json:"bar"`
+				}{}),
+			},
+			want: `{
+				"properties": {
+					"foo": { "type": "string" },
+					"bar": { "type": "string" }
+				}
+			}`,
+		},
+		{
+			name: "embedded struct with a json tag stays nested",
+			args: args{
+				t: reflect.TypeOf(struct {
+					NamedStruct `json:"named"`
+				}{}),
+			},
+			want: `{
+				"definitions": {
+					"NamedStruct": {
+						"properties": {
+							"foo": { "type": "string" }
+						}
+					}
+				},
+				"properties": {
+					"named": { "ref": "NamedStruct" }
+				}
+			}`,
+		},
+		{
+			name: "fields tagged - are skipped",
+			args: args{
+				t: reflect.TypeOf(struct {
+					Foo string `json:"foo"`
+					Bar string `json:"-"`
+				}{}),
+			},
+			want: `{
+				"properties": {
+					"foo": { "type": "string" }
+				}
+			}`,
+		},
+		{
 			name: "timestamp",
 			args: args{
 				t: reflect.TypeOf(struct {

--- a/lokerpc/schema_test.go
+++ b/lokerpc/schema_test.go
@@ -354,6 +354,85 @@ func TestTypeSchema(t *testing.T) {
 	}
 }
 
+// EmbedBase is shadowed by the structs below.
+type EmbedBase struct {
+	Value string `json:"value"`
+	Other string `json:"other"`
+}
+
+// Parent field shadows the embedded one, embed declared first.
+type OverrideFirst struct {
+	EmbedBase
+	Value int `json:"value"`
+}
+
+// Same, but embed declared last: declaration order must not matter.
+type OverrideLast struct {
+	Value int `json:"value"`
+	EmbedBase
+}
+
+// Parent shadows with omitempty: the embedded required "value" must not
+// survive alongside it, or the schema is invalid.
+type OverrideOmit struct {
+	EmbedBase
+	Value int `json:"value,omitempty"`
+}
+
+func TestTypeSchemaEmbeddedOverride(t *testing.T) {
+	int32Schema := jtd.Schema{Type: jtd.TypeInt32}
+	stringSchema := jtd.Schema{Type: jtd.TypeString}
+
+	tests := []struct {
+		name string
+		typ  reflect.Type
+		want jtd.Schema
+	}{
+		{
+			name: "embed first",
+			typ:  reflect.TypeOf(OverrideFirst{}),
+			want: jtd.Schema{Properties: map[string]jtd.Schema{
+				"value": int32Schema,
+				"other": stringSchema,
+			}},
+		},
+		{
+			name: "embed last",
+			typ:  reflect.TypeOf(OverrideLast{}),
+			want: jtd.Schema{Properties: map[string]jtd.Schema{
+				"value": int32Schema,
+				"other": stringSchema,
+			}},
+		},
+		{
+			name: "shadowed by omitempty",
+			typ:  reflect.TypeOf(OverrideOmit{}),
+			want: jtd.Schema{
+				Properties:         map[string]jtd.Schema{"other": stringSchema},
+				OptionalProperties: map[string]jtd.Schema{"value": int32Schema},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tdefs := map[reflect.Type]*NamedSchema{}
+			TypeSchema(tt.typ, tdefs)
+			got := tdefs[tt.typ].Schema
+
+			if err := got.Validate(); err != nil {
+				t.Errorf("Validate() error = %v", err)
+			}
+
+			if !reflect.DeepEqual(got, tt.want) {
+				gotstr, _ := json.MarshalIndent(got, "", "  ")
+				wantstr, _ := json.MarshalIndent(tt.want, "", "  ")
+				t.Errorf("TypeSchema() = %s, want %s", gotstr, wantstr)
+			}
+		})
+	}
+}
+
 // selfEmbed embeds itself; promoting its fields must terminate.
 type selfEmbed struct {
 	*selfEmbed

--- a/lokerpc/schema_test.go
+++ b/lokerpc/schema_test.go
@@ -353,3 +353,19 @@ func TestTypeSchema(t *testing.T) {
 		})
 	}
 }
+
+// selfEmbed embeds itself; promoting its fields must terminate.
+type selfEmbed struct {
+	*selfEmbed
+	Value string `json:"value"`
+}
+
+func TestTypeSchemaSelfEmbedded(t *testing.T) {
+	tdefs := map[reflect.Type]*NamedSchema{}
+	TypeSchema(reflect.TypeFor[selfEmbed](), tdefs)
+
+	got := tdefs[reflect.TypeFor[selfEmbed]()].Schema
+	if _, ok := got.Properties["value"]; !ok || len(got.Properties) != 1 {
+		t.Errorf("Properties = %v, want only value", got.Properties)
+	}
+}

--- a/lokerpc/schema_test.go
+++ b/lokerpc/schema_test.go
@@ -433,17 +433,17 @@ func TestTypeSchemaEmbeddedOverride(t *testing.T) {
 	}
 }
 
-// selfEmbed embeds itself; promoting its fields must terminate.
-type selfEmbed struct {
-	*selfEmbed
+// SelfEmbed embeds itself; promoting its fields must terminate.
+type SelfEmbed struct {
+	*SelfEmbed
 	Value string `json:"value"`
 }
 
 func TestTypeSchemaSelfEmbedded(t *testing.T) {
 	tdefs := map[reflect.Type]*NamedSchema{}
-	TypeSchema(reflect.TypeFor[selfEmbed](), tdefs)
+	TypeSchema(reflect.TypeFor[SelfEmbed](), tdefs)
 
-	got := tdefs[reflect.TypeFor[selfEmbed]()].Schema
+	got := tdefs[reflect.TypeFor[SelfEmbed]()].Schema
 	if _, ok := got.Properties["value"]; !ok || len(got.Properties) != 1 {
 		t.Errorf("Properties = %v, want only value", got.Properties)
 	}

--- a/lokerpc/server.go
+++ b/lokerpc/server.go
@@ -334,14 +334,23 @@ func newMetaHandler(meta any) http.HandlerFunc {
 }
 
 func FieldNames(i interface{}) []string {
+	return fieldNames(reflect.TypeOf(i))
+}
+
+func fieldNames(t reflect.Type) []string {
 	pm := []string{}
-	t := reflect.TypeOf(i)
 
 	for n := 0; n < t.NumField(); n++ {
 		f := t.Field(n)
 		name, _ := parseTag(f.Tag.Get("json"))
 		if name == "-" {
 			continue
+		}
+		if f.Anonymous && name == "" {
+			if ft := indirect(f.Type); ft.Kind() == reflect.Struct && ft != timeType {
+				pm = append(pm, fieldNames(ft)...)
+				continue
+			}
 		}
 		if name == "" {
 			name = f.Name

--- a/lokerpc/server_test.go
+++ b/lokerpc/server_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -109,5 +110,23 @@ func TestMountHandlers(t *testing.T) {
 				t.Errorf("want body %q, got %q", tt.wantBody, gotBody)
 			}
 		})
+	}
+}
+
+func TestFieldNames(t *testing.T) {
+	type Pagination struct {
+		Limit          *int    `json:"limit,omitempty"`
+		NextPageCursor *string `json:"nextPageCursor,omitempty"`
+	}
+
+	got := FieldNames(struct {
+		OrganizationUID string `json:"organizationUid"`
+		Secret          string `json:"-"`
+		Pagination
+	}{})
+
+	want := []string{"organizationUid", "limit", "nextPageCursor"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("FieldNames() = %v, want %v", got, want)
 	}
 }


### PR DESCRIPTION
Internal change only

This PR adds support for embedded structs within the RPC service struct definitions

<!--
## Related PRs
- https://github.com/LOKE/example/pull/1
-->

<!--
## Rollback Instructions

-->

## Screenshots / Videos

https://github.com/user-attachments/assets/a831b163-1a14-46e4-95a0-f4b4d93906df

The above pagination is only possible now that the RPC exposes the correct JSON schema for the CLI to generate so now operator will actually send the correct request type.

Here is the go type:
```go
type ListPaymentsRequest struct {
	OrganizationUID string              `json:"organizationUid" validate:"required,ulid"` // Scope all results to this organization.
	Filters         ListPaymentsFilters `json:"filters"`                                  // Optional filter criteria; zero value returns all payments for the org.
	pagination.Request
}
```

**Before**

<img width="390" height="260" alt="image" src="https://github.com/user-attachments/assets/f77718c6-735a-4544-92ce-5926de79151d" />

**After**

<img width="458" height="366" alt="image" src="https://github.com/user-attachments/assets/95051c45-92c6-4e9f-aaa4-dc6e7088f14e" />

##  I have:
- [x] Run and tested the code and provided clear evidence of this above
- [x] Self reviewed the code and removed extraneous comments, debug logging, checked code style
- [x] Listed any dependant PRs required for this change
- [x] Added tests where practical and possible
- [x] Documented a way to roll this change back if it is more than a code revert

_all the above **must** be ticked_
