### PR TITLE
chore: re-export New from `errors` package

### DIFF
--- a/errors/error.go
+++ b/errors/error.go
@@ -107,3 +107,8 @@ func Is(err, target error) bool {
 func Unwrap(err error) error {
 	return errors.Unwrap(err)
 }
+
+// New is a re-export of [errors.New] for convenience.
+func New(text string) error {
+	return errors.New(text)
+}


### PR DESCRIPTION
Internal change only

Missing a re-export (goal is to never import the std errors package in our go projects)

<!--
## Related PRs
- https://github.com/LOKE/example/pull/1
-->

<!--
## Rollback Instructions

-->

## Screenshots / Videos

##  I have:
- [ ] Run and tested the code and provided clear evidence of this above
- [x] Self reviewed the code and removed extraneous comments, debug logging, checked code style
- [x] Listed any dependant PRs required for this change
- [x] Added tests where practical and possible
- [x] Documented a way to roll this change back if it is more than a code revert

_all the above **must** be ticked_
